### PR TITLE
Add Docker Image CI build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          image: lfoppiano/pdf-tei-editor
+          image: ${{ secrets.DOCKERHUB_USERNAME }}/pdf-tei-editor
           registry: docker.io
           pushImage: ${{ github.event_name != 'pull_request' }}
           tags: latest


### PR DESCRIPTION
This should work. Now is uploading at `lfoppiano/pdf-tei-editor:latest` but you can edit that in the config file. 

You also need to create a token with writing permission and add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN in the github secrets. 

Moved to a separate branch 