### PR TITLE
fix: Prevent data loss from silent XML auto-save failures

### DIFF
--- a/app/src/modules/codemirror/codemirror-utils.js
+++ b/app/src/modules/codemirror/codemirror-utils.js
@@ -20,17 +20,23 @@ import { EditorView, ViewPlugin } from "@codemirror/view";
 import { syntaxTree } from "@codemirror/language";
 
 /**
- * Links CodeMirror's syntax tree nodes representing XML elements with their corresponding DOM elements
- * parsed by DOMParser by traversing both trees recursively and storing references to each other in 
- * two Maps. Enhanced to handle XML processing instructions and other non-element nodes.
+ * Links CodeMirror's syntax tree nodes representing XML elements with their corresponding DOM
+ * elements parsed by DOMParser by traversing both trees in lockstep and storing cross-references
+ * in two Maps. Processing instructions, comments, and text nodes between elements are skipped
+ * transparently on both sides.
+ *
+ * Algorithm: walks both trees with a pair of sibling cursors; at each element pair it validates
+ * the tag names match and recurses into their first element child. Per-element memory is O(1) —
+ * no intermediate arrays of children are materialised.
  *
  * @param {EditorView} view The CodeMirror EditorView instance.
  * @param {SyntaxNode} syntaxNode The root syntax node of the CodeMirror XML editor's syntax tree.
  * @param {Element|Document} domNode The (root) DOM element parsed by DOMParser.
- * @throws {Error} If the tags of the syntax tree node and the DOM node do not match.
- * @returns {{syntaxToDom: Map<number, Node>, domToSyntax: Map<Node, number> }} An object containing two WeakMaps: syntaxToDom and domToSyntax.
- *                  - syntaxToDom: Maps the position of syntax tree nodes to DOM nodes.
- *                  - domToSyntax: Maps DOM nodes to syntax tree nodes' positions.
+ * @throws {Error} If the root nodes are not Document/DOCUMENT_NODE, if a root element cannot be
+ *   found on either side, if tag names mismatch, or if the two trees have a different number of
+ *   element children at any level.
+ * @returns {{syntaxToDom: Map<number, Node>, domToSyntax: Map<Node, number> }} Two Maps linking
+ *   syntax tree node positions to DOM nodes and vice versa.
  */
 export function linkSyntaxTreeWithDOM(view, syntaxNode, domNode) {
   /** @type {Map<number, Node>} */
@@ -40,153 +46,112 @@ export function linkSyntaxTreeWithDOM(view, syntaxNode, domNode) {
 
   /**
    * @param {SyntaxNode} node
+   * @returns {string}
    */
   const getText = node => view.state.doc.sliceString(node.from, node.to);
 
   /**
-   * Helper to find the first element node in a tree
-   * @param {SyntaxNode|Node} node Starting node
-   * @param {boolean} [isDOM=false] Whether this is a DOM node (true) or syntax node (false)
-   * @returns {SyntaxNode|Element|null} First element node found or null
+   * Advance along a syntax-node sibling chain until the first Element is found.
+   * @param {SyntaxNode | null} node
+   * @returns {SyntaxNode | null}
    */
-  function findFirstElement(node, isDOM = false) {
+  function findFirstSyntaxElement(node) {
     while (node) {
-      if (isDOM) {
-        /** @type {Node} */
-        const domNode = /** @type {Node} */ (node);
-        if (domNode.nodeType === Node.ELEMENT_NODE) return /** @type {Element} */ (domNode);
-      } else {
-        /** @type {SyntaxNode} */
-        const syntaxNode = /** @type {SyntaxNode} */ (node);
-        if (syntaxNode.name === "Element") return syntaxNode;
-      }
-      const nextNode = node.nextSibling;
-      if (!nextNode) break;
-      node = nextNode;
+      if (node.name === "Element") return node;
+      node = node.nextSibling;
     }
     return null;
   }
 
   /**
-   * Collects all element children from a parent node
-   * @param {SyntaxNode|Node} parent Parent node
-   * @param {boolean} [isDOM=false] Whether this is a DOM node (true) or syntax node (false)
-   * @returns {Array<SyntaxNode|Element>} Array of element nodes
+   * Advance along a DOM sibling chain until the first Element is found.
+   * @param {Node | null} node
+   * @returns {Element | null}
    */
-  function collectElementChildren(parent, isDOM = false) {
-    const elements = [];
-    let child = parent.firstChild;
-    
-    while (child) {
-      const element = findFirstElement(child, isDOM);
-      if (element) {
-        elements.push(element);
-        child = element.nextSibling;
-      } else {
-        break;
-      }
+  function findFirstDomElement(node) {
+    while (node) {
+      if (node.nodeType === Node.ELEMENT_NODE) return /** @type {Element} */ (node);
+      node = node.nextSibling;
     }
-    return elements;
+    return null;
   }
 
   /**
-   * @param {SyntaxNode} syntaxNode
-   * @param {Element} domNode
+   * Resolve the TagName syntax node under an Element. Lezer's XML grammar shapes Elements as
+   * `Element -> (OpenTag | SelfClosingTag) ...`, where the start tag's children are `<`, TagName,
+   * attributes..., `>`. Returns the TagName node or null when the grammar shape is broken (e.g.
+   * during partial parsing of malformed input).
+   * @param {SyntaxNode} element
+   * @returns {SyntaxNode | null}
    */
-  function recursiveLink(syntaxNode, domNode) {
+  function resolveTagNameNode(element) {
+    const tag = element.firstChild?.firstChild?.nextSibling;
+    return tag && tag.name === "TagName" ? tag : null;
+  }
 
-    if (!syntaxNode || !domNode) {
-      throw new Error("Invalid arguments. Syntax node and DOM node must not be null.");
-    }
-
-    // Enhanced: Find the first element in each tree, handling processing instructions
-    const syntaxElement = /** @type {SyntaxNode|null} */ (findFirstElement(syntaxNode, false));
-    const domElement = /** @type {Element|null} */ (findFirstElement(domNode, true));
-
-    // If we couldn't find matching element nodes, return empty maps
-    if (!syntaxElement || !domElement) {
-      return {
-        syntaxToDom: new Map(),
-        domToSyntax: new Map()
-      };
-    }
-
-    // Check if the found elements are valid
-    if (!syntaxElement || syntaxElement.name !== "Element") {
-      throw new Error(`Unexpected node type: ${syntaxElement?.name}. Expected "Element".`);
-    }
-
-    // make sure we have a tag name child
-    let syntaxTagNode = syntaxElement.firstChild?.firstChild?.nextSibling;
-    if (!syntaxTagNode || syntaxTagNode.name !== "TagName") {
-      const text = getText(syntaxElement);
-      if (text === "<") {
-        // hack
-        syntaxTagNode = syntaxTagNode?.nextSibling
-      } else {
-        throw new Error(`Expected a TagName child node in syntax tree. Found: ${text}`);
-      }
-    }
-
+  /**
+   * Link one element pair and recurse into their element children using parallel sibling cursors.
+   * Side-effect only: writes into the outer syntaxToDom / domToSyntax maps.
+   * @param {SyntaxNode} syntaxElement
+   * @param {Element} domElement
+   */
+  function linkPair(syntaxElement, domElement) {
+    const syntaxTagNode = resolveTagNameNode(syntaxElement);
     if (!syntaxTagNode) {
-      throw new Error('Could not find TagName node after processing');
+      throw new Error(`Expected a TagName child node in syntax tree. Found: ${getText(syntaxElement)}`);
     }
     const syntaxTagName = getText(syntaxTagNode);
-    const domTagName = /** @type {Element} */ (domElement).tagName;
-
-    // Verify that the tag names match
+    const domTagName = domElement.tagName;
     if (syntaxTagName !== domTagName) {
       throw new Error(`Tag mismatch: Syntax tree has ${syntaxTagName}, DOM has ${domTagName}`);
     }
 
-    // Store references to each other - since the syntax tree is regenerated on each lookup,
-    // we need to store the unique positions of each node as reference
-    syntaxToDom.set(/** @type {SyntaxNode} */ (syntaxElement).from, domElement);
-    domToSyntax.set(domElement, /** @type {SyntaxNode} */ (syntaxElement).from);
+    // Store references. The syntax tree is regenerated on each lookup, so we key by position.
+    syntaxToDom.set(syntaxElement.from, domElement);
+    domToSyntax.set(domElement, syntaxElement.from);
 
-    // Enhanced: Use robust child collection and pairing
-    const syntaxChildren = collectElementChildren(syntaxElement, false);
-    const domChildren = collectElementChildren(domElement, true);
-
-    // Recursively link the children by pairs
-    const minChildren = Math.min(syntaxChildren.length, domChildren.length);
-    for (let i = 0; i < minChildren; i++) {
-      recursiveLink(/** @type {SyntaxNode} */ (syntaxChildren[i]), /** @type {Element} */ (domChildren[i]));
+    // Two-cursor walk: advance both sides element-by-element without building arrays.
+    let syntaxChild = findFirstSyntaxElement(syntaxElement.firstChild);
+    let domChild = findFirstDomElement(domElement.firstChild);
+    while (syntaxChild && domChild) {
+      linkPair(syntaxChild, domChild);
+      syntaxChild = findFirstSyntaxElement(syntaxChild.nextSibling);
+      domChild = findFirstDomElement(domChild.nextSibling);
     }
 
-    // Check for mismatched child counts
-    if (syntaxChildren.length > domChildren.length) {
-      const extraSyntax = syntaxChildren.slice(domChildren.length);
-      throw new Error(`Syntax tree has more child elements than the DOM tree: ${extraSyntax.map(n => getText(/** @type {SyntaxNode} */ (n))).join(', ')}`);
+    // One side has more element children than the other.
+    if (syntaxChild && !domChild) {
+      const extras = [];
+      for (let n = syntaxChild; n; n = findFirstSyntaxElement(n.nextSibling)) {
+        extras.push(getText(n));
+      }
+      throw new Error(`Syntax tree has more child elements than the DOM tree: ${extras.join(', ')}`);
     }
-    if (domChildren.length > syntaxChildren.length) {
-      const extraDOM = domChildren.slice(syntaxChildren.length);
-      throw new Error(`DOM tree has more child elements than the syntax tree: ${extraDOM.map(n => /** @type {Element} */ (n).tagName).join(', ')}`);
+    if (domChild && !syntaxChild) {
+      const extras = [];
+      for (let n = domChild; n; n = findFirstDomElement(n.nextSibling)) {
+        extras.push(n.tagName);
+      }
+      throw new Error(`DOM tree has more child elements than the syntax tree: ${extras.join(', ')}`);
     }
-    return {
-      syntaxToDom,
-      domToSyntax
-    };
   }
 
   if (syntaxNode.name !== "Document" || domNode.nodeType !== Node.DOCUMENT_NODE) {
     throw new Error("Invalid arguments. The root syntax node must be the top Document node and the DOM node must be a document. Received: " +
       `syntaxNode: ${syntaxNode.name}, domNode: ${Object.keys(Node)[domNode.nodeType - 1]}`);
   }
-  
-  // Enhanced: Find root elements, skipping processing instructions and other non-element nodes
-  const syntaxRoot = syntaxNode.firstChild ? /** @type {SyntaxNode|null} */ (findFirstElement(syntaxNode.firstChild, false)) : null;
-  const domRoot = domNode.firstChild ? /** @type {Element|null} */ (findFirstElement(domNode.firstChild, true)) : null;
-  
+
+  // Locate the root Element on each side, skipping PIs, comments, and whitespace text nodes.
+  const syntaxRoot = findFirstSyntaxElement(syntaxNode.firstChild);
+  const domRoot = findFirstDomElement(domNode.firstChild);
+
   if (!syntaxRoot || !domRoot) {
     console.warn("Could not find root elements in one or both trees");
-    return {
-      syntaxToDom: new Map(),
-      domToSyntax: new Map()
-    };
+    return { syntaxToDom, domToSyntax };
   }
-  
-  return recursiveLink(syntaxRoot, domRoot);
+
+  linkPair(syntaxRoot, domRoot);
+  return { syntaxToDom, domToSyntax };
 }
 
 /**

--- a/app/src/modules/xml-editor-dom-sync.js
+++ b/app/src/modules/xml-editor-dom-sync.js
@@ -1,0 +1,272 @@
+/**
+ * XML editor DOM <-> syntax tree synchronisation.
+ *
+ * Encapsulates the two-way mapping between the CodeMirror Lezer syntax tree and a
+ * DOM document produced by `DOMParser`. The goal of this class is to make the
+ * state machine around "XML in the editor is valid / invalid / has diverging
+ * trees" explicit and testable, and to guarantee that transient malformed states
+ * (which are normal during editing) never leave the editor in an unrecoverable
+ * state.
+ *
+ * Key invariants:
+ *   1. `getXmlTree()` returns the most recent *parseable* DOM document, even if
+ *      the editor content is currently malformed. Callers that must know whether
+ *      it reflects the current editor text check {@link isSynced}.
+ *   2. A failed link step (tag mismatch, child-count mismatch) never discards the
+ *      previous good tree or maps. It leaves `isSynced` false and records the
+ *      error in {@link getLastSyncError}.
+ *   3. The result object returned from {@link sync} reports the outcome to the
+ *      caller (e.g. `XMLEditor`) so it can emit the appropriate events without
+ *      inspecting internal state.
+ *
+ * The concrete parsing/linking logic lives in:
+ *   - `DOMParser.parseFromString` (browser API) for text -> DOM.
+ *   - `linkSyntaxTreeWithDOM` from `codemirror-utils.js` for DOM <-> syntax map.
+ *
+ * @import {SyntaxNode, Tree} from '@lezer/common'
+ * @import {EditorView} from '@codemirror/view'
+ * @import {Diagnostic} from '@codemirror/lint'
+ */
+
+import { syntaxTree, syntaxParserRunning } from '@codemirror/language';
+import { linkSyntaxTreeWithDOM, parseXmlError } from './codemirror/codemirror-utils.js';
+
+/**
+ * @typedef {object} ProcessingInstructionData
+ * @property {string} target
+ * @property {string} data
+ * @property {number} position
+ * @property {string} fullText
+ */
+
+/**
+ * @typedef {object} SyncError
+ * @property {'parse' | 'link'} stage - Where the failure occurred.
+ * @property {string} message - Human-readable description.
+ * @property {Diagnostic} [diagnostic] - Present for `stage === 'parse'`; carries
+ *   position info suitable for CodeMirror lint display.
+ */
+
+/**
+ * @typedef {object} SyncResult
+ * @property {boolean} ok - True if both parse and link succeeded.
+ * @property {'wellFormed' | 'malformed' | 'linkFailed' | 'empty'} status -
+ *   Fine-grained outcome for event emission by the caller.
+ * @property {Diagnostic} [diagnostic] - Parser diagnostic when `status === 'malformed'`.
+ * @property {Error} [linkError] - Original error when `status === 'linkFailed'`.
+ */
+
+/**
+ * @typedef {object} Logger
+ * @property {(message: any) => void} debug
+ * @property {(message: any) => void} warn
+ * @property {(message: any) => void} error
+ */
+
+export class XmlEditorDomSync {
+  /** Latest successfully-parsed DOM tree. Null only before first successful parse or after {@link clear}. @type {Document | null} */
+  #lastGoodXmlTree = null;
+
+  /** Latest successfully-captured Lezer syntax tree. @type {Tree | null} */
+  #lastGoodSyntaxTree = null;
+
+  /** syntax node position -> DOM node. Null if never linked or after {@link clear}. @type {Map<number, Node> | null} */
+  #syntaxToDom = null;
+
+  /** DOM node -> syntax node position. @type {Map<Node, number> | null} */
+  #domToSyntax = null;
+
+  /** @type {ProcessingInstructionData[]} */
+  #processingInstructions = [];
+
+  /** Cached editor text content from the most recent {@link sync}. @type {string} */
+  #editorContent = '';
+
+  /**
+   * True iff `#lastGoodXmlTree`, `#lastGoodSyntaxTree`, and the maps reflect the
+   * current editor text. Becomes false whenever the editor text diverges (either
+   * because parsing fails, linking fails, or {@link clear} was called).
+   * @type {boolean}
+   */
+  #isSynced = false;
+
+  /** @type {SyncError | null} */
+  #lastSyncError = null;
+
+  /** @type {Logger} */
+  #logger;
+
+  /**
+   * @param {object} [options]
+   * @param {Logger} [options.logger]
+   */
+  constructor({ logger } = {}) {
+    this.#logger = logger ?? /** @type {Logger} */ (/** @type {unknown} */ (console));
+  }
+
+  /**
+   * Re-parse the editor content and, if well-formed, link its syntax tree to the
+   * DOM. Returns a {@link SyncResult} describing the outcome; throws only on
+   * programming errors (never on malformed input or link failures).
+   *
+   * On failure the previous last-known-good tree and maps are preserved so that
+   * callers can continue to serve navigation/query requests.
+   *
+   * @param {EditorView} view
+   * @returns {Promise<SyncResult>}
+   */
+  async sync(view) {
+    const content = view.state.doc.toString();
+    this.#editorContent = content;
+
+    if (content.trim() === '') {
+      // Empty editor: reset everything, not treated as an error.
+      this.#lastGoodXmlTree = null;
+      this.#lastGoodSyntaxTree = null;
+      this.#syntaxToDom = null;
+      this.#domToSyntax = null;
+      this.#processingInstructions = [];
+      this.#isSynced = false;
+      this.#lastSyncError = null;
+      return { ok: false, status: 'empty' };
+    }
+
+    // Stage 1: parse text -> DOM.
+    const doc = new DOMParser().parseFromString(content, 'application/xml');
+    const errorNode = doc.querySelector('parsererror');
+    if (errorNode) {
+      const diagnostic = parseXmlError(errorNode, view.state.doc);
+      this.#isSynced = false;
+      this.#lastSyncError = {
+        stage: 'parse',
+        message: `Line ${diagnostic.line}, column ${diagnostic.column}: ${diagnostic.message}`,
+        diagnostic
+      };
+      this.#logger.debug(
+        `XmlEditorDomSync: parse failed (${this.#lastSyncError.message}); keeping last-good tree.`
+      );
+      return { ok: false, status: 'malformed', diagnostic };
+    }
+
+    // Stage 2: wait for the syntax parser if it is still processing the latest text.
+    if (syntaxParserRunning(view)) {
+      while (syntaxParserRunning(view)) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+      }
+    }
+    const newSyntaxTree = syntaxTree(view.state);
+
+    // Stage 3: link syntax tree to DOM.
+    try {
+      const { syntaxToDom, domToSyntax } = linkSyntaxTreeWithDOM(
+        view,
+        newSyntaxTree.topNode,
+        doc
+      );
+      this.#lastGoodXmlTree = doc;
+      this.#lastGoodSyntaxTree = newSyntaxTree;
+      this.#syntaxToDom = syntaxToDom;
+      this.#domToSyntax = domToSyntax;
+      this.#processingInstructions = this.#detectProcessingInstructions(doc);
+      this.#isSynced = true;
+      this.#lastSyncError = null;
+      return { ok: true, status: 'wellFormed' };
+    } catch (error) {
+      this.#isSynced = false;
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.#lastSyncError = { stage: 'link', message: err.message };
+      this.#logger.warn(
+        `XmlEditorDomSync: link failed (${err.message}); keeping previous maps.`
+      );
+      return { ok: false, status: 'linkFailed', linkError: err };
+    }
+  }
+
+  /**
+   * Reset all state. Called when the editor is cleared or a new document is loaded.
+   */
+  clear() {
+    this.#lastGoodXmlTree = null;
+    this.#lastGoodSyntaxTree = null;
+    this.#syntaxToDom = null;
+    this.#domToSyntax = null;
+    this.#processingInstructions = [];
+    this.#editorContent = '';
+    this.#isSynced = false;
+    this.#lastSyncError = null;
+  }
+
+  /**
+   * Returns the most recent successfully-parsed DOM document. This may be stale
+   * if the editor content has since become malformed or the link step has failed;
+   * use {@link isSynced} to determine freshness.
+   * @returns {Document | null}
+   */
+  getXmlTree() {
+    return this.#lastGoodXmlTree;
+  }
+
+  /** @returns {Tree | null} */
+  getSyntaxTree() {
+    return this.#lastGoodSyntaxTree;
+  }
+
+  /** @returns {Map<number, Node> | null} */
+  getSyntaxToDom() {
+    return this.#syntaxToDom;
+  }
+
+  /** @returns {Map<Node, number> | null} */
+  getDomToSyntax() {
+    return this.#domToSyntax;
+  }
+
+  /** @returns {ProcessingInstructionData[]} */
+  getProcessingInstructions() {
+    return this.#processingInstructions;
+  }
+
+  /** @returns {string} */
+  getEditorContent() {
+    return this.#editorContent;
+  }
+
+  /**
+   * True iff the last-good trees and maps reflect the editor text at the time of
+   * the most recent {@link sync}. Callers that mutate the DOM tree and push the
+   * result back into the editor MUST check this.
+   * @returns {boolean}
+   */
+  isSynced() {
+    return this.#isSynced;
+  }
+
+  /** @returns {SyncError | null} */
+  getLastSyncError() {
+    return this.#lastSyncError;
+  }
+
+  /**
+   * @param {Document} xmlTree
+   * @returns {ProcessingInstructionData[]}
+   */
+  #detectProcessingInstructions(xmlTree) {
+    /** @type {ProcessingInstructionData[]} */
+    const out = [];
+    for (let i = 0; i < xmlTree.childNodes.length; i++) {
+      const node = xmlTree.childNodes[i];
+      if (node.nodeType === Node.PROCESSING_INSTRUCTION_NODE) {
+        const piNode = /** @type {ProcessingInstruction} */ (node);
+        out.push({
+          target: piNode.target,
+          data: piNode.data,
+          position: i,
+          fullText: `<?${piNode.target}${piNode.data ? ' ' + piNode.data : ''}?>`
+        });
+      }
+    }
+    return out;
+  }
+}
+
+export default XmlEditorDomSync;

--- a/app/src/modules/xml-editor-draft-store.js
+++ b/app/src/modules/xml-editor-draft-store.js
@@ -1,0 +1,185 @@
+/**
+ * Draft persistence for the XML editor.
+ *
+ * Drafts are written to `localStorage` on every editor update so that users never
+ * lose work when:
+ *   - The editor holds malformed XML and auto-save is blocked.
+ *   - The network or server is unavailable when auto-save attempts to write.
+ *   - The browser tab is closed or refreshed before a save completes.
+ *
+ * Key scheme: `xmleditor.draft.<stableId>`
+ * Value: JSON-encoded {@link DraftRecord}.
+ *
+ * Writes are best-effort: quota or serialization errors are logged but never thrown
+ * so that a draft write failure cannot break editing.
+ */
+
+/**
+ * @typedef {object} DraftRecord
+ * @property {string} stableId - The stable id of the document the draft belongs to.
+ * @property {string} content - Raw editor text (may be malformed XML).
+ * @property {number} savedAt - Unix timestamp (ms) when the draft was written.
+ * @property {number} documentVersion - Editor's document version at save time.
+ * @property {boolean} wellFormed - Whether the content parsed as well-formed XML.
+ */
+
+/**
+ * @typedef {object} Logger
+ * @property {(message: any) => void} debug
+ * @property {(message: any) => void} warn
+ * @property {(message: any) => void} error
+ */
+
+const KEY_PREFIX = 'xmleditor.draft.';
+
+/**
+ * Maximum serialized draft length to attempt writing. `localStorage` quotas are
+ * typically 5-10 MB per origin; we cap at ~2 MB to leave headroom for other
+ * persisted state. If a document exceeds this, the draft is skipped with a warning.
+ */
+const MAX_DRAFT_BYTES = 2 * 1024 * 1024;
+
+export class XmlEditorDraftStore {
+  /** @type {Logger} */
+  #logger;
+
+  /** @type {Storage} */
+  #storage;
+
+  /**
+   * @param {object} [options]
+   * @param {Logger} [options.logger] - Defaults to console.
+   * @param {Storage} [options.storage] - Defaults to window.localStorage.
+   */
+  constructor({ logger, storage } = {}) {
+    this.#logger = logger ?? /** @type {Logger} */ (/** @type {unknown} */ (console));
+    this.#storage = storage ?? window.localStorage;
+  }
+
+  /**
+   * @param {string} stableId
+   * @returns {string}
+   */
+  #key(stableId) {
+    return `${KEY_PREFIX}${stableId}`;
+  }
+
+  /**
+   * Persist a draft for the given document. Failures are logged, never thrown.
+   *
+   * @param {string} stableId
+   * @param {string} content - Raw editor text.
+   * @param {number} documentVersion - Current XMLEditor document version.
+   * @param {boolean} wellFormed - Whether the content currently parses as well-formed XML.
+   * @returns {boolean} True if the draft was written, false if skipped/failed.
+   */
+  saveDraft(stableId, content, documentVersion, wellFormed) {
+    if (!stableId) {
+      return false;
+    }
+    if (typeof content !== 'string') {
+      return false;
+    }
+    if (content.length > MAX_DRAFT_BYTES) {
+      this.#logger.warn(
+        `XmlEditorDraftStore: draft for ${stableId} exceeds ${MAX_DRAFT_BYTES} bytes (${content.length}); skipping persistence.`
+      );
+      return false;
+    }
+    /** @type {DraftRecord} */
+    const record = {
+      stableId,
+      content,
+      savedAt: Date.now(),
+      documentVersion,
+      wellFormed: Boolean(wellFormed)
+    };
+    try {
+      this.#storage.setItem(this.#key(stableId), JSON.stringify(record));
+      return true;
+    } catch (error) {
+      // QuotaExceededError, security errors in private mode, etc.
+      this.#logger.warn(`XmlEditorDraftStore: saveDraft failed for ${stableId}: ${String(error)}`);
+      return false;
+    }
+  }
+
+  /**
+   * Load a draft for the given document.
+   *
+   * @param {string} stableId
+   * @returns {DraftRecord | null} Parsed draft, or null if none exists or the record is invalid.
+   */
+  loadDraft(stableId) {
+    if (!stableId) {
+      return null;
+    }
+    let raw;
+    try {
+      raw = this.#storage.getItem(this.#key(stableId));
+    } catch (error) {
+      this.#logger.warn(`XmlEditorDraftStore: loadDraft read failed for ${stableId}: ${String(error)}`);
+      return null;
+    }
+    if (!raw) {
+      return null;
+    }
+    try {
+      const parsed = /** @type {DraftRecord} */ (JSON.parse(raw));
+      if (!parsed || typeof parsed !== 'object' || typeof parsed.content !== 'string') {
+        return null;
+      }
+      return parsed;
+    } catch (error) {
+      this.#logger.warn(`XmlEditorDraftStore: loadDraft parse failed for ${stableId}: ${String(error)}`);
+      // Corrupt record - remove it.
+      this.clearDraft(stableId);
+      return null;
+    }
+  }
+
+  /**
+   * Returns true if a draft exists for the given document.
+   * @param {string} stableId
+   * @returns {boolean}
+   */
+  hasDraft(stableId) {
+    return this.loadDraft(stableId) !== null;
+  }
+
+  /**
+   * Remove the draft for the given document. No-op if none exists.
+   * @param {string} stableId
+   */
+  clearDraft(stableId) {
+    if (!stableId) {
+      return;
+    }
+    try {
+      this.#storage.removeItem(this.#key(stableId));
+    } catch (error) {
+      this.#logger.warn(`XmlEditorDraftStore: clearDraft failed for ${stableId}: ${String(error)}`);
+    }
+  }
+
+  /**
+   * List all draft stable-ids currently stored.
+   * @returns {string[]}
+   */
+  listDraftIds() {
+    const ids = [];
+    try {
+      for (let i = 0; i < this.#storage.length; i++) {
+        const key = this.#storage.key(i);
+        if (key && key.startsWith(KEY_PREFIX)) {
+          ids.push(key.slice(KEY_PREFIX.length));
+        }
+      }
+    } catch (error) {
+      this.#logger.warn(`XmlEditorDraftStore: listDraftIds failed: ${String(error)}`);
+    }
+    return ids;
+  }
+}
+
+export default XmlEditorDraftStore;

--- a/app/src/modules/xmleditor.js
+++ b/app/src/modules/xmleditor.js
@@ -51,10 +51,11 @@ import { indentWithTab } from "@codemirror/commands"
 
 // custom modules
 
-import { selectionChangeListener, linkSyntaxTreeWithDOM, isExtension, parseXmlError } from './codemirror/codemirror-utils.js';
+import { selectionChangeListener, isExtension } from './codemirror/codemirror-utils.js';
 import { EventEmitter } from './event-emitter.js';
 import { xmlTagSync } from "./codemirror/xml-tag-sync.js";
 import { createCompletionSource } from './codemirror/autocomplete.js';
+import { XmlEditorDomSync } from './xml-editor-dom-sync.js';
 
 /**
  * An XML editor based on the CodeMirror editor, which keeps the CodeMirror syntax tree and a DOM XML 
@@ -93,22 +94,13 @@ export class XMLEditor extends EventEmitter {
 
   #documentVersion = 0 // internal counter to track changes in the document
 
-  #editorContent = '' // a cache of the raw text content of the editor
-
-  /** @type {Map<number, Node> | null} */
-  #syntaxToDom = null; // Maps syntax tree nodes to DOM nodes
-
-  /** @type {Map<Node, number> | null} */
-  #domToSyntax = null; // Maps DOM nodes to syntax tree nodes
-
-  /** @type {Document | null} */
-  #xmlTree = null; // the xml document tree or null if xml text is invalid
-
-  /** @type {Tree | null} */
-  #syntaxTree = null // the lezer syntax tree
-
-  /** @type {ProcessingInstructionData[]} */
-  #processingInstructions = [] // processing instructions found in the document
+  /**
+   * Encapsulates DOM <-> syntax tree synchronisation and preserves the last-known
+   * good state across transient malformed edits. All access to `#xmlTree`,
+   * `#syntaxTree`, and the syntax/DOM maps goes through this instance.
+   * @type {XmlEditorDomSync}
+   */
+  #domSync;
 
   /** @type {boolean} */
   #isReady = false
@@ -182,6 +174,7 @@ export class XMLEditor extends EventEmitter {
     super();
 
     this.#logger = logger ?? console
+    this.#domSync = new XmlEditorDomSync({ logger: this.#logger })
     this.#markAsNotReady()
 
     const editorDiv = document.getElementById(editorDivId);
@@ -443,6 +436,7 @@ export class XMLEditor extends EventEmitter {
       changes: { from: 0, to: this.#view.state.doc.length, insert: "" },
       selection: EditorSelection.cursor(0)
     });
+    this.#domSync.clear();
     this.#documentVersion = 0;
     this.#editorIsDirty = false;
   }
@@ -659,19 +653,21 @@ export class XMLEditor extends EventEmitter {
   }
 
   /**
-   * Returns the current content of the editor.
+   * Returns the current content of the editor (as of the most recent sync).
    * @returns {string} - The current XML content.
    */
   getEditorContent() {
-    return this.#editorContent;
+    return this.#domSync.getEditorContent();
   }
 
   /**
-   * Returns the XML document tree.
+   * Returns the most recent successfully-parsed XML document tree. This may be
+   * stale with respect to the current editor text when the editor content is
+   * malformed; use {@link isSynced} to test freshness.
    * @returns {Document|null} - The XML document tree.
    */
   getXmlTree() {
-    return this.#xmlTree;
+    return this.#domSync.getXmlTree();
   }
 
   /**
@@ -679,30 +675,18 @@ export class XMLEditor extends EventEmitter {
    * @returns {ProcessingInstructionData[]} Array of processing instruction objects
    */
   getProcessingInstructions() {
-    return this.#processingInstructions;
+    return this.#domSync.getProcessingInstructions();
   }
 
   /**
-   * Detects processing instructions in the loaded XML document
-   * @returns {ProcessingInstructionData[]} Array of processing instruction objects
+   * True iff the DOM tree and syntax-tree maps reflect the current editor text.
+   * Becomes false while the editor content is malformed or the syntax/DOM link
+   * has failed. Callers that plan to mutate the in-memory DOM tree and push the
+   * result back into the editor MUST check this first.
+   * @returns {boolean}
    */
-  detectProcessingInstructions() {
-    if (!this.#xmlTree) return [];
-    /** @type {ProcessingInstructionData[]} */
-    const processingInstructions = [];
-    for (let i = 0; i < this.#xmlTree.childNodes.length; i++) {
-      const node = this.#xmlTree.childNodes[i];
-      if (node.nodeType === Node.PROCESSING_INSTRUCTION_NODE) {        
-        const piNode = /** @type {ProcessingInstruction} */ (node);
-        processingInstructions.push({
-          target: piNode.target,
-          data: piNode.data,
-          position: i,
-          fullText: `<?${piNode.target}${piNode.data ? ' ' + piNode.data : ''}?>`
-        });
-      }
-    }
-    return processingInstructions;
+  isSynced() {
+    return this.#domSync.isSynced();
   }
 
   /**
@@ -710,10 +694,11 @@ export class XMLEditor extends EventEmitter {
    * @returns {string} 
    */
   getXML() {
-    if (!this.#xmlTree) {
+    const tree = this.#domSync.getXmlTree();
+    if (!tree) {
       return ''
     }
-    return this.#serialize(this.#xmlTree, false);
+    return this.#serialize(tree, false);
   }
 
   /**
@@ -756,7 +741,7 @@ export class XMLEditor extends EventEmitter {
   async updateNodeFromEditor(element) {
     const { to, from } = this.getSyntaxNodeFromDomNode(element)
     element.outerHTML = this.#view.state.doc.sliceString(from, to)
-    this.#updateMaps()
+    await this.#domSync.sync(this.#view);
   }
 
   /**
@@ -764,7 +749,7 @@ export class XMLEditor extends EventEmitter {
    * @returns {Tree | null}
    */
   getSyntaxTree() {
-    return this.#syntaxTree;
+    return this.#domSync.getSyntaxTree();
   }
 
   /**
@@ -774,7 +759,7 @@ export class XMLEditor extends EventEmitter {
    * null if uninitialized or undefined if the node is not connected to the editor content
    */
   getDomNodePosition(domNode) {
-    return this.#domToSyntax?.get(domNode)
+    return this.#domSync.getDomToSyntax()?.get(domNode)
   }
 
   /**
@@ -829,8 +814,9 @@ export class XMLEditor extends EventEmitter {
    * @returns {Node}
    */
   getDomNodeAt(pos) {
-    if (!this.#syntaxToDom) {
-      this.#updateMaps()
+    let syntaxToDom = this.#domSync.getSyntaxToDom();
+    if (!syntaxToDom) {
+      throw new Error("Syntax/DOM maps are not available; editor is not synced.");
     }
     let syntaxNode = this.getSyntaxNodeAt(pos);
     // find the element parent if necessary
@@ -839,7 +825,7 @@ export class XMLEditor extends EventEmitter {
       if (!parent) break;
       syntaxNode = parent;
     }
-    const domNode = syntaxNode && this.#syntaxToDom?.get(syntaxNode.from);
+    const domNode = syntaxNode && syntaxToDom.get(syntaxNode.from);
     if (!domNode) {
       throw new Error(`No DOM node found at position ${pos}`);
     }
@@ -853,14 +839,15 @@ export class XMLEditor extends EventEmitter {
    * @throws {Error} If the XML tree is not loaded
    */
   getDomNodesByXpath(xpath) {
-    if (!this.#xmlTree) {
+    const xmlTree = this.#domSync.getXmlTree();
+    if (!xmlTree) {
       throw new Error("XML tree is not loaded.");
     }
     if (!xpath) {
       throw new Error("XPath is not provided.");
     }
-    
-    const xpathResult = this.#xmlTree.evaluate(xpath, this.#xmlTree, this.namespaceResolver, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+
+    const xpathResult = xmlTree.evaluate(xpath, xmlTree, this.namespaceResolver, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
     const result = []
     let node;
     while ((node = xpathResult.iterateNext())) {
@@ -876,15 +863,16 @@ export class XMLEditor extends EventEmitter {
    * @throws {Error} If the XML tree is not loaded
    */
   countDomNodesByXpath(xpath) {
-    if (!this.#xmlTree) {
+    const xmlTree = this.#domSync.getXmlTree();
+    if (!xmlTree) {
       throw new Error("XML tree is not loaded.");
     }
     if (!xpath) {
       throw new Error("XPath is not provided.");
     }
     xpath = `count(${xpath})`
-    
-    return this.#xmlTree.evaluate(xpath, this.#xmlTree, this.namespaceResolver, XPathResult.NUMBER_TYPE, null).numberValue;
+
+    return xmlTree.evaluate(xpath, xmlTree, this.namespaceResolver, XPathResult.NUMBER_TYPE, null).numberValue;
   }
 
   /**
@@ -894,14 +882,15 @@ export class XMLEditor extends EventEmitter {
    * @throws {Error} If the XML tree is not loaded or if no nodes match the XPath expression.
    */
   getDomNodeByXpath(xpath) {
-    if (!this.#xmlTree) {
+    const xmlTree = this.#domSync.getXmlTree();
+    if (!xmlTree) {
       throw new Error("XML tree is not loaded.");
     }
     if (!xpath) {
       throw new Error("XPath is not provided.");
     }
-    
-    const xpathResult = this.#xmlTree.evaluate(xpath, this.#xmlTree, this.namespaceResolver, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+
+    const xpathResult = xmlTree.evaluate(xpath, xmlTree, this.namespaceResolver, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
     const result = xpathResult.singleNodeValue;
     //console.warn(xpath, result)
     return result
@@ -914,14 +903,15 @@ export class XMLEditor extends EventEmitter {
    * @throws {Error} If the XML tree is not loaded, if no DOM node match the XPath expression, or no syntax node can be found for the DOM node.
    */
   getSyntaxNodeByXpath(xpath) {
-    if (!this.#domToSyntax) {
-      this.#updateMaps()
+    const domToSyntax = this.#domSync.getDomToSyntax();
+    if (!domToSyntax) {
+      throw new Error(`No syntax node found for XPath: ${xpath} (editor is not synced).`);
     }
     const node = this.getDomNodeByXpath(xpath)
     if (!node) {
       throw new Error(`No XML node found for XPath: ${xpath}`);
     }
-    const pos = this.#domToSyntax?.get(node);
+    const pos = domToSyntax.get(node);
     if (!pos) {
       throw new Error(`No syntax node found for XPath: ${xpath}`);
     }
@@ -947,7 +937,7 @@ export class XMLEditor extends EventEmitter {
    * @throws {Error} If the XML tree is not loaded.
    */
   foldByXpath(xpath) {
-    if (!this.#xmlTree) {
+    if (!this.#domSync.getXmlTree()) {
       throw new Error("XML tree is not loaded.");
     }
     if (!xpath) {
@@ -988,7 +978,7 @@ export class XMLEditor extends EventEmitter {
    * @throws {Error} If the XML tree is not loaded.
    */
   unfoldByXpath(xpath) {
-    if (!this.#xmlTree) {
+    if (!this.#domSync.getXmlTree()) {
       throw new Error("XML tree is not loaded.");
     }
     if (!xpath) {
@@ -1088,19 +1078,56 @@ export class XMLEditor extends EventEmitter {
   }
 
   /**
-   * Synchronize xml document with the editor content
+   * Synchronise xml document with the editor content. Delegates to
+   * {@link XmlEditorDomSync} and emits the appropriate well-formed / not-
+   * well-formed events. Never throws; any error short of a programming bug
+   * leaves the editor in a recoverable state and is logged.
    * @returns {Promise<void>}
    */
   async sync() {
     try {
-      if (await this.#updateTrees()) {
-        this.#updateMaps()
+      const result = await this.#domSync.sync(this.#view);
+
+      if (result.status === 'wellFormed') {
+        this.#logger.debug("Document was updated and is well-formed.")
+        // xmlTagSync depends on a valid DOM; re-enable when well-formed.
+        this.#view.dispatch({
+          effects: this.#xmlTagSyncCompartment.reconfigure(xmlTagSync)
+        });
+        await this.emit("editorXmlWellFormed", null);
+      } else if (result.status === 'malformed' && result.diagnostic) {
+        this.#logger.debug(
+          `Document was updated but is not well-formed: Line ${result.diagnostic.line}, column ${result.diagnostic.column}: ${result.diagnostic.message}`
+        );
+        // Disable xmlTagSync while the tree is not parseable.
+        this.#view.dispatch({
+          effects: this.#xmlTagSyncCompartment.reconfigure([])
+        });
+        await this.emit("editorXmlNotWellFormed", [result.diagnostic]);
+      } else if (result.status === 'linkFailed') {
+        // Previous last-good tree is preserved inside #domSync; we emit a
+        // malformed-like event so that UI reflects the broken sync state.
+        this.#logger.warn(
+          `Linking DOM and syntax tree failed: ${result.linkError?.message ?? 'unknown error'}`
+        );
+        await this.emit("editorXmlNotWellFormed", [
+          {
+            from: 0,
+            to: 0,
+            severity: 'error',
+            message: `DOM/syntax link failed: ${result.linkError?.message ?? 'unknown error'}`,
+            line: 1,
+            column: 1
+          }
+        ]);
       }
+      // status === 'empty' falls through silently.
     } catch (error) {
-      this.#logger.warn(`Linking DOM and syntax tree failed: ${String(error)}`)
+      // Defensive - sync() is documented to not throw.
+      this.#logger.warn(`Unexpected error during sync: ${String(error)}`);
     }
 
-    // once we at least tried to synchronize, we can mark the editor as ready
+    // once we at least tried to synchronise, we can mark the editor as ready
     await this.emit("editorReady", null);
   }
 
@@ -1263,67 +1290,8 @@ export class XMLEditor extends EventEmitter {
     await promise;
   }
 
-  /**
-   * Synchronizes the syntax tree and the XML DOM
-   * @returns {Promise<Boolean>} Returns true if the tree updates were successful and false if not
-   */
-  async #updateTrees() {
-    this.#editorContent = this.#view.state.doc.toString();
-    if (this.#editorContent.trim() === "") {
-      this.#xmlTree = null;
-      return false;
-    }
-    const doc = new DOMParser().parseFromString(this.#editorContent, "application/xml");
-    const errorNode = doc.querySelector("parsererror");
-    if (errorNode) {
-      const diagnostic = parseXmlError(errorNode, this.#view.state.doc);
-      this.#logger.debug(`Document was updated but is not well-formed: : Line ${diagnostic.line}, column ${diagnostic.column}: ${diagnostic.message}`)
-      await this.emit("editorXmlNotWellFormed", [diagnostic])
-      this.#xmlTree = null;
-      this.#view.dispatch({
-        effects: this.#xmlTagSyncCompartment.reconfigure([])
-      });
-      return false;
-    }
-    this.#logger.debug("Document was updated and is well-formed.")
-    await this.emit("editorXmlWellFormed", null)
-    this.#xmlTree = doc;
-    this.#view.dispatch({
-      effects: this.#xmlTagSyncCompartment.reconfigure(xmlTagSync)
-    });
-
-    // Track processing instructions for better synchronization
-    this.#processingInstructions = this.detectProcessingInstructions();
-    
-    if (this.#processingInstructions.length > 0) {
-        //console.log(`Found ${this.#processingInstructions.length} processing instruction(s):`, 
-        //this.#processingInstructions.map(pi => pi.fullText));
-    }
-
-    // the syntax tree construction is async, so we need to wait for it to complete
-    if (syntaxParserRunning(this.#view)) {
-      this.#logger.log('Waiting for syntax tree to be ready...')
-      while (syntaxParserRunning(this.#view)) {
-        await new Promise(resolve => setTimeout(resolve, 200))
-      }
-      this.#logger.log('Syntax tree is ready.')
-    }
-    this.#syntaxTree = syntaxTree(this.#view.state);
-    return true
-  }
-
-  /**
-   * Creates internal maps that link the syntax tree and the dom nodes
-   */
-  #updateMaps() {
-    if (!(this.#xmlTree && this.#syntaxTree)) {
-      throw new Error("XML or Syntax tree missing")
-    }
-    const maps = linkSyntaxTreeWithDOM(this.#view, this.#syntaxTree.topNode, this.#xmlTree);
-    const { syntaxToDom, domToSyntax } = maps;
-    this.#syntaxToDom = syntaxToDom;
-    this.#domToSyntax = domToSyntax;
-  }
+  // Tree / DOM / map synchronisation is delegated to {@link XmlEditorDomSync}.
+  // See this.sync() above.
 
   /**
    * Extracts edition title from TEI XML string

--- a/app/src/plugins/filedata.js
+++ b/app/src/plugins/filedata.js
@@ -24,6 +24,20 @@ import { notify } from '../modules/sl-utils.js'
 await registerTemplate('gc-menu-item', 'gc-menu-item.html')
 
 /**
+ * Thrown by {@link FiledataPlugin#saveXml} when the editor's XML is not well-formed.
+ * Callers can use `error instanceof NoValidXmlError` to distinguish this from transport
+ * or server-side errors and avoid presenting a generic "Save failed" message for what is
+ * really a client-side validation problem.
+ */
+export class NoValidXmlError extends Error {
+  /** @param {string} message */
+  constructor(message) {
+    super(message);
+    this.name = 'NoValidXmlError';
+  }
+}
+
+/**
  * File data management plugin
  */
 class FiledataPlugin extends Plugin {
@@ -267,21 +281,30 @@ class FiledataPlugin extends Plugin {
   }
 
   /**
-   * Saves the current XML content to a file
+   * Saves the current XML content to a file.
+   *
+   * If the editor contains malformed XML this method throws a {@link NoValidXmlError} so
+   * callers can distinguish it from a transport or server error. Callers that auto-save
+   * (e.g. XmlEditorPlugin.#saveIfDirty) should pre-check `xmlEditor.getXmlTree()` and keep
+   * the user's content in a local draft instead of attempting the save.
+   *
    * @param {string} fileHash The hash identifying the XML file on the server
    * @param {Boolean?} saveAsNewVersion Optional flag to save the file content as a new version
    * @returns {Promise<{file_id:string, status:string}>} An object with file_id (stable file identifier) and status
-   * @throws {Error}
+   * @throws {NoValidXmlError} when the editor has no parseable XML tree
+   * @throws {Error} on transport/server failures
    */
   async saveXml(fileHash, saveAsNewVersion = false) {
     this.#logger.info(`Saving XML${saveAsNewVersion ? " as new version" : ""}...`);
     if (!this.#xmlEditor.getXmlTree()) {
-      throw new Error("Cannot save: No XML valid document in the editor");
+      throw new NoValidXmlError(
+        'Cannot save: the XML in the editor is not well-formed. Fix XML errors and try again.'
+      );
     }
     try {
-      // Show saving status
+      // Show saving status in the headerbar (right-aligned).
       if (this.savingStatusWidget) {
-        this.getDependency('xmleditor').addStatusbarWidget(this.savingStatusWidget, 'left', 10);
+        this.getDependency('xmleditor').addHeaderbarWidget(this.savingStatusWidget, 'right', 3);
       }
       const xmlContent = this.#xmlEditor.getXML()
       const result = await this.#client.saveXml(xmlContent, fileHash, saveAsNewVersion);
@@ -290,7 +313,7 @@ class FiledataPlugin extends Plugin {
       // clear status message after 1 second
       setTimeout(() => {
         if (this.savingStatusWidget) {
-          this.getDependency('xmleditor').removeStatusbarWidget(this.savingStatusWidget.id);
+          this.getDependency('xmleditor').removeHeaderbarWidget(this.savingStatusWidget.id);
         }
       }, 1000);
     }

--- a/app/src/plugins/xmleditor.js
+++ b/app/src/plugins/xmleditor.js
@@ -32,6 +32,14 @@ import * as tei_utils from '../modules/tei-utils.js'
 import { prettyPrintXmlDom } from '../modules/xml-utils.js'
 import Plugin from '../modules/plugin-base.js'
 import ep from '../extension-points.js'
+import XmlEditorDraftStore from '../modules/xml-editor-draft-store.js'
+
+/**
+ * Adaptive draft save throttle (ms): well-formed typing is flushed less often, malformed
+ * typing is flushed more aggressively so no keystroke is lost before the save can complete.
+ */
+const DRAFT_THROTTLE_MS_WELL_FORMED = 500;
+const DRAFT_THROTTLE_MS_MALFORMED = 200;
 
 // Register templates
 await registerTemplate('xmleditor-headerbar', 'xmleditor-headerbar.html')
@@ -113,6 +121,7 @@ class XmlEditorPlugin extends Plugin {
       deps: ['logger', 'client']
     });
     this.#xmlEditor = new NavXmlEditor('codemirror-container');
+    this.#draftStore = new XmlEditorDraftStore({ logger: console });
   }
 
   get #logger() { return this.getDependency('logger') }
@@ -186,6 +195,20 @@ class XmlEditorPlugin extends Plugin {
   /** @type {string|null} */
   #hashBeingSaved = null;
 
+  // Draft persistence and save-status reporting
+  /** @type {XmlEditorDraftStore} */
+  #draftStore;
+  /** @type {ReturnType<typeof setTimeout>|null} */
+  #draftSaveTimeout = null;
+  /** @type {StatusText|null} */
+  #saveStatusWidget = null;
+  /** @type {boolean} */
+  #saveBlockedShownToUser = false;
+  /** @type {string|null} */
+  #lastLoadedStableId = null;
+  /** @type {string} */
+  #originalDocumentTitle = document.title;
+
   /**
    * Returns a proxy that exposes plugin-level methods alongside the NavXmlEditor API.
    * Plugin methods take precedence; all other property accesses fall through to the inner editor.
@@ -195,7 +218,7 @@ class XmlEditorPlugin extends Plugin {
   getApi() {
     const plugin = this;
     const inner = this.#xmlEditor;
-    const pluginMethods = new Set(['addStatusbarWidget', 'removeStatusbarWidget', 'setReadOnlyContext', 'addToolbarWidget', 'appendToEditor', 'saveIfDirty', 'openDocumentAtLine', 'inProgress']);
+    const pluginMethods = new Set(['addStatusbarWidget', 'removeStatusbarWidget', 'addHeaderbarWidget', 'removeHeaderbarWidget', 'setReadOnlyContext', 'addToolbarWidget', 'appendToEditor', 'saveIfDirty', 'openDocumentAtLine', 'inProgress']);
     return /** @type {NavXmlEditor} */ (new Proxy(inner, {
       get(_target, prop) {
         if (pluginMethods.has(String(prop))) {
@@ -281,6 +304,29 @@ class XmlEditorPlugin extends Plugin {
       icon: 'lock-fill',
       variant: 'warning',
       name: 'readOnlyStatus'
+    });
+
+    // Save status widget (persistent visible indicator when auto-save cannot reach the server).
+    // It is added to the headerbar (right) whenever auto-save is blocked (malformed XML, network
+    // failure, save still in flight after long malformed edits, etc.) and removed once a
+    // successful server save occurs. It replaces the earlier silent debug-level "Not saving" log.
+    this.#saveStatusWidget = PanelUtils.createText({
+      text: 'Unsaved changes',
+      icon: 'exclamation-triangle-fill',
+      variant: 'warning',
+      name: 'saveStatus'
+    });
+    // Make it clickable so the user can see a concise explanation if they ask.
+    this.#saveStatusWidget.clickable = true;
+    this.#saveStatusWidget.tooltip = 'Auto-save is blocked. Click for details.';
+    this.#saveStatusWidget.addEventListener('widget-click', () => {
+      notify(
+        'Auto-save is currently blocked, usually because the XML is not well-formed. ' +
+        'Your edits are buffered locally (draft). Fix the XML errors or use File → Download ' +
+        'to export a copy.',
+        'warning',
+        'exclamation-triangle'
+      );
     });
 
     // Update UI to register named widgets (kept for cross-plugin ui access in access-control.js)
@@ -391,6 +437,10 @@ class XmlEditorPlugin extends Plugin {
     // Update cursor position on editor updates (typing, etc.)
     this.#xmlEditor.on('editorUpdate', () => this.#updateCursorPosition());
 
+    // Schedule a local-draft save on every editor update so no typed content is lost
+    // even while the server save is blocked (e.g. malformed XML, connection lost).
+    this.#xmlEditor.on('editorUpdate', () => this.#scheduleDraftSave());
+
     // Handle indentation detection before loading XML
     this.#xmlEditor.on('editorBeforeLoad', (xml) => {
       const indentUnit = detectXmlIndentation(xml);
@@ -403,8 +453,17 @@ class XmlEditorPlugin extends Plugin {
     this.#xmlEditor.on('editorAfterLoad', () => {
       testLog('XML_EDITOR_DOCUMENT_LOADED', { isReady: true });
 
-      this.#xmlEditor.whenReady().then(() => {
+      this.#xmlEditor.whenReady().then(async () => {
         this.#xmlEditor.setLineWrapping(this.#getLineWrappingPreference());
+
+        // Offer to restore a local draft if one exists for this stable id and differs from
+        // the freshly loaded server content. Drafts arise when a previous session ended while
+        // auto-save was blocked (typically because the XML was malformed).
+        const currentStableId = this.state?.xml ?? null;
+        this.#lastLoadedStableId = currentStableId;
+        if (currentStableId) {
+          await this.#maybeRestoreDraft(currentStableId);
+        }
 
         setTimeout(async () => {
           if (!this.state?.xpath && this.state?.variant) {
@@ -440,6 +499,22 @@ class XmlEditorPlugin extends Plugin {
         }
       });
     }
+
+    // Guard navigation when the editor has unsaved work or a buffered draft. This shows the
+    // browser's built-in "Leave site?" confirmation. The actual wording is controlled by the
+    // browser; we only need to assign a non-empty returnValue and preventDefault().
+    window.addEventListener('beforeunload', (evt) => {
+      const dirty = this.#xmlEditor.isDirty();
+      const blocked = this.#saveStatusWidget?.isConnected;
+      // Only prompt when there is risk of losing unsaved work. A clean editor never prompts.
+      if (!dirty && !blocked) return;
+      // Flush the draft synchronously so whatever is in the editor is recoverable on reload
+      // even if the user chooses to leave. This is best-effort; localStorage writes are fast.
+      this.#flushDraftNow();
+      evt.preventDefault();
+      // Legacy browsers require returnValue to be set to a non-empty string.
+      evt.returnValue = 'You have unsaved changes in the XML editor.';
+    });
 
     // Create node navigation widgets for statusbar center section
     this.#prevNodeBtn = PanelUtils.createButton({
@@ -530,7 +605,7 @@ class XmlEditorPlugin extends Plugin {
       }
 
       if (validationStatusWidget && !validationStatusWidget.isConnected) {
-        this.#statusbar.add(validationStatusWidget, 'left', 5);
+        this.#headerbar.add(validationStatusWidget, 'right', 2);
       }
       // @ts-ignore
       this.#xmlEditorEl.querySelector('.cm-content').classList.add('invalid-xml');
@@ -545,7 +620,7 @@ class XmlEditorPlugin extends Plugin {
         this.#logger.warn('Error clearing diagnostics on well-formed XML: ' + String(error));
       }
       if (validationStatusWidget && validationStatusWidget.isConnected) {
-        this.#statusbar.removeById(validationStatusWidget.id);
+        this.#headerbar.removeById(validationStatusWidget.id);
       }
     });
 
@@ -579,6 +654,15 @@ class XmlEditorPlugin extends Plugin {
     // When diff is cleared externally (e.g. logout), hide the merge view
     if (!state.diff && this.#xmlEditor.isMergeViewActive()) {
       await this.#xmlEditor.hideMergeView();
+    }
+
+    // Track the currently loaded document so draft-save knows which key to write to.
+    // We explicitly avoid clearing this on a null state.xml because `clear()` is called
+    // during the transition — keep the last id until editorAfterLoad for the next document
+    // reassigns it. The draft of the departed document remains on disk for later restore.
+    if (state.xml && state.xml !== this.#lastLoadedStableId) {
+      // Will be re-set in editorAfterLoad once load completes; defensively update here too.
+      this.#lastLoadedStableId = state.xml;
     }
 
     // Invalidate extractor cache when user changes so it is refreshed lazily
@@ -744,6 +828,24 @@ class XmlEditorPlugin extends Plugin {
   }
 
   /**
+   * Add a widget to the XML editor headerbar.
+   * @param {HTMLElement} widget
+   * @param {'left'|'center'|'right'} position
+   * @param {number} priority
+   */
+  addHeaderbarWidget(widget, position, priority) {
+    this.#headerbar.add(widget, position, priority)
+  }
+
+  /**
+   * Remove a widget from the XML editor headerbar by ID.
+   * @param {string} widgetId
+   */
+  removeHeaderbarWidget(widgetId) {
+    this.#headerbar.removeById(widgetId)
+  }
+
+  /**
    * Set the context text on the read-only status widget.
    * @param {string} text
    */
@@ -842,7 +944,16 @@ class XmlEditorPlugin extends Plugin {
   }
 
   /**
-   * Save the current XML file if the editor is "dirty"
+   * Save the current XML file if the editor is "dirty".
+   *
+   * The method is guarded against several failure modes that previously caused silent data
+   * loss (see issue #358):
+   *   - If the editor has no valid XML tree (malformed content), the server save is SKIPPED
+   *     but the user is informed via a persistent headerbar widget, and the current editor
+   *     content is still buffered to localStorage as a draft.
+   *   - If the editor was mutated while a save was in flight (documentVersion changed), the
+   *     editor is NOT marked clean, so the next delayed-update cycle will save again.
+   *   - On save errors the user is notified via toast AND the persistent widget.
    */
   async #saveIfDirty() {
     const fileHash = this.state?.xml;
@@ -850,15 +961,40 @@ class XmlEditorPlugin extends Plugin {
     const hasXmlTree = !!this.#xmlEditor.getXmlTree();
     const isDirty = this.#xmlEditor.isDirty();
 
-    if (isHashBeingSaved || !fileHash || !hasXmlTree || !isDirty) {
-      let reason;
-      if (isHashBeingSaved) reason = 'Already saving document';
-      if (!fileHash) reason = 'No document';
-      if (!hasXmlTree) reason = 'No valid xml document';
-      if (!isDirty) reason = "Document hasn't changed";
-      this.#logger.debug(`Not saving: ${reason}`);
+    if (!fileHash) {
+      // No document loaded – nothing to save, nothing to warn about.
+      this.#setSaveBlocked(false);
       return;
     }
+    if (isHashBeingSaved) {
+      // A save is already in flight for this file hash; the delayed-update cycle will retry
+      // once it completes. This is not a user-visible problem.
+      this.#logger.debug('Not saving: Already saving document');
+      return;
+    }
+    if (!isDirty) {
+      this.#logger.debug("Not saving: Document hasn't changed");
+      // Anything previously flagged blocked was user-facing; clear it on a clean state.
+      this.#setSaveBlocked(false);
+      return;
+    }
+    if (!hasXmlTree) {
+      // This is the CRITICAL path for issue #358: the editor content is malformed so the
+      // server cannot be reached without risking data corruption. The local draft save
+      // (scheduled from editorUpdate) keeps the typed content safe. Tell the user.
+      this.#logger.warn('Not saving to server: XML is not well-formed. ' +
+        'Edits are buffered as a local draft until the XML can be parsed again.');
+      this.#setSaveBlocked(true,
+        'Unsaved – fix XML errors', 'exclamation-triangle-fill', 'warning');
+      // Force a synchronous draft flush so nothing is in limbo if the tab is closed now.
+      this.#flushDraftNow();
+      return;
+    }
+
+    // Capture the document version BEFORE the save so we can detect edits that happened
+    // during the await and avoid the race where we would otherwise mark a dirty editor
+    // clean (dropping unsaved keystrokes).
+    const versionAtStart = this.#xmlEditor.getDocumentVersion();
 
     try {
       this.#hashBeingSaved = fileHash;
@@ -866,6 +1002,7 @@ class XmlEditorPlugin extends Plugin {
       const result = await filedata.saveXml(fileHash);
       if (!result || typeof result != 'object' || !result.status) {
         this.#logger.warn('Invalid result from filedata.saveXml: ' + result);
+        this.#setSaveBlocked(true, 'Unsaved – server error', 'exclamation-octagon-fill', 'danger');
         return;
       }
       if (result.status == 'unchanged') {
@@ -876,13 +1013,179 @@ class XmlEditorPlugin extends Plugin {
           await this.dispatchStateChange({ xml: result.file_id });
         }
       }
-      this.#xmlEditor.markAsClean();
+
+      const versionAtEnd = this.#xmlEditor.getDocumentVersion();
+      if (versionAtEnd === versionAtStart) {
+        // No edits happened during the save — safe to mark clean.
+        this.#xmlEditor.markAsClean();
+        // Server has an authoritative copy; drop the local draft to avoid stale restore prompts.
+        if (this.#lastLoadedStableId) {
+          this.#draftStore.clearDraft(this.#lastLoadedStableId);
+        }
+      } else {
+        // Something was typed while saving; next delayed update will trigger another save.
+        this.#logger.debug(
+          `Document version advanced during save (${versionAtStart} -> ${versionAtEnd}); ` +
+          'leaving dirty flag set so the next save cycle covers the new edits.'
+        );
+      }
+      // Successful server save clears any previously shown warning.
+      this.#setSaveBlocked(false);
     } catch (error) {
       this.#logger.error(error);
       notify(`Save failed: ${String(error)}`, 'danger', 'exclamation-octagon');
+      this.#setSaveBlocked(true, 'Unsaved – save failed', 'exclamation-octagon-fill', 'danger');
+      // Make sure a local draft exists in case the user reloads before the next retry.
+      this.#flushDraftNow();
     } finally {
       this.#hashBeingSaved = null;
     }
+  }
+
+  /**
+   * Toggle the persistent "unsaved" headerbar widget.
+   * @param {boolean} blocked
+   * @param {string} [text]
+   * @param {string} [icon]
+   * @param {'default'|'warning'|'danger'|'success'} [variant]
+   */
+  #setSaveBlocked(blocked, text = 'Unsaved changes', icon = 'exclamation-triangle-fill', variant = 'warning') {
+    if (!this.#saveStatusWidget) return;
+    if (blocked) {
+      this.#saveStatusWidget.text = text;
+      this.#saveStatusWidget.icon = icon;
+      // StatusText variant attribute drives the CSS colour. Typed as string at runtime.
+      /** @type {any} */ (this.#saveStatusWidget).variant = variant;
+      if (!this.#saveStatusWidget.isConnected) {
+        this.#headerbar.add(this.#saveStatusWidget, 'right', 1);
+      }
+      if (!this.#saveBlockedShownToUser) {
+        this.#saveBlockedShownToUser = true;
+        notify(
+          'Auto-save is blocked. Your recent edits are buffered locally but not saved to the server. ' +
+          'Fix XML errors or use File → Download to export a copy.',
+          'warning',
+          'exclamation-triangle'
+        );
+      }
+    } else {
+      if (this.#saveStatusWidget.isConnected) {
+        this.#headerbar.removeById(this.#saveStatusWidget.id);
+      }
+      this.#saveBlockedShownToUser = false;
+    }
+    this.#updateBrowserTitle();
+  }
+
+  /**
+   * Schedules a local-draft save with adaptive throttle: malformed content is flushed more
+   * eagerly so no keystroke is lost before the next save can complete.
+   */
+  #scheduleDraftSave() {
+    const stableId = this.#lastLoadedStableId ?? this.state?.xml ?? null;
+    if (!stableId) return;
+    const wellFormed = !!this.#xmlEditor.getXmlTree();
+    const delay = wellFormed ? DRAFT_THROTTLE_MS_WELL_FORMED : DRAFT_THROTTLE_MS_MALFORMED;
+    if (this.#draftSaveTimeout) clearTimeout(this.#draftSaveTimeout);
+    this.#draftSaveTimeout = setTimeout(() => {
+      this.#draftSaveTimeout = null;
+      this.#flushDraftNow();
+    }, delay);
+    // Keep the tab title in sync with the dirty state.
+    this.#updateBrowserTitle();
+  }
+
+  /**
+   * Persists the current editor content to localStorage immediately. Safe to call at any time;
+   * silently no-ops when there is no loaded document.
+   */
+  #flushDraftNow() {
+    const stableId = this.#lastLoadedStableId ?? this.state?.xml ?? null;
+    if (!stableId) return;
+    try {
+      const content = this.#xmlEditor.getEditorContent();
+      if (!content) return;
+      const wellFormed = !!this.#xmlEditor.getXmlTree();
+      this.#draftStore.saveDraft(
+        stableId,
+        content,
+        this.#xmlEditor.getDocumentVersion(),
+        wellFormed
+      );
+    } catch (error) {
+      this.#logger.warn('Failed to write local draft: ' + String(error));
+    }
+  }
+
+  /**
+   * If a local draft exists for the freshly loaded document and differs from the server
+   * content, offer the user a chance to restore it. Declined drafts are discarded.
+   * @param {string} stableId
+   */
+  async #maybeRestoreDraft(stableId) {
+    let record;
+    try {
+      record = this.#draftStore.loadDraft(stableId);
+    } catch (error) {
+      this.#logger.warn('Failed to read local draft: ' + String(error));
+      return;
+    }
+    if (!record) return;
+
+    const serverContent = this.#xmlEditor.getEditorContent();
+    if (record.content === serverContent) {
+      // Draft matches server state – nothing to restore, clear the record.
+      this.#draftStore.clearDraft(stableId);
+      return;
+    }
+
+    const savedAt = new Date(record.savedAt).toLocaleString();
+    const wellFormedTag = record.wellFormed ? 'well-formed' : 'MALFORMED';
+    const shouldRestore = confirm(
+      `A locally-buffered draft of this document was found from ${savedAt} (${wellFormedTag}).\n\n` +
+      'This draft was created because auto-save could not reach the server. ' +
+      'Restore the draft into the editor?\n\n' +
+      'OK = restore draft (you can still save to the server once the XML is valid).\n' +
+      'Cancel = discard draft and use the server version.'
+    );
+
+    if (!shouldRestore) {
+      this.#draftStore.clearDraft(stableId);
+      return;
+    }
+
+    try {
+      await this.#xmlEditor.loadXml(record.content);
+      notify('Local draft restored. Fix any XML errors and the document will auto-save.',
+        'primary', 'info-circle');
+      // The editor will re-emit editorUpdate events once the user types again; mark dirty
+      // so the save cycle kicks in if the restored draft is itself well-formed.
+      if (record.wellFormed) {
+        // loadXml resets dirty to false; force a dirty save cycle by scheduling a draft flush.
+        this.#scheduleDraftSave();
+      } else {
+        this.#setSaveBlocked(true, 'Unsaved – fix XML errors', 'exclamation-triangle-fill', 'warning');
+      }
+    } catch (error) {
+      this.#logger.error('Failed to restore draft: ' + String(error));
+      notify('Failed to restore draft: ' + String(error), 'danger', 'exclamation-octagon');
+    }
+  }
+
+  /**
+   * Updates the browser tab title to reflect unsaved/error state. Prefixes the original
+   * document title with "● " when there is unsaved work, or with "⚠ " when auto-save is
+   * actively blocked, so users can notice from other tabs.
+   */
+  #updateBrowserTitle() {
+    const base = this.#originalDocumentTitle;
+    let prefix = '';
+    const dirty = this.#xmlEditor.isDirty();
+    const blocked = this.#saveStatusWidget?.isConnected;
+    if (blocked) prefix = '⚠ ';
+    else if (dirty) prefix = '● ';
+    const newTitle = prefix + base;
+    if (document.title !== newTitle) document.title = newTitle;
   }
 
   /**
@@ -892,6 +1195,18 @@ class XmlEditorPlugin extends Plugin {
     if (!this.state?.xml) return;
     if (this.state.editorReadOnly) {
       notify('You are not allowed to edit this artifact', 'warning', 'exclamation-triangle');
+      return;
+    }
+    // Refuse to mutate the in-memory DOM when it is stale relative to the editor buffer.
+    // Overwriting the editor from a stale DOM tree would silently discard the user's
+    // latest keystrokes (one of the root causes traced in issue #358).
+    if (!this.#xmlEditor.isSynced()) {
+      notify(
+        'Cannot rename the artifact right now because the XML in the editor is not well-formed. ' +
+        'Please fix the XML errors and try again.',
+        'warning',
+        'exclamation-triangle'
+      );
       return;
     }
     const currentLabel = this.#titleWidget.text;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pdf-tei-editor",
-    "version": "0.44.0",
+    "version": "0.44.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "pdf-tei-editor",
-            "version": "0.44.0",
+            "version": "0.44.1",
             "hasInstallScript": true,
             "dependencies": {
                 "@codemirror/autocomplete": "^6.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pdf-tei-editor",
-    "version": "0.44.0",
+    "version": "0.44.1",
     "type": "module",
     "scripts": {
         "ci": "uv sync && npm install",

--- a/tests/unit/js/sync-algorithm.test.js
+++ b/tests/unit/js/sync-algorithm.test.js
@@ -1,565 +1,390 @@
 #!/usr/bin/env node
 
 /**
- * Test suite for XML Editor syntax tree <-> DOM synchronization algorithm
- * Uses Node.js built-in test runner (available in Node 18+)
+ * Test suite for XmlEditorDomSync — the class that encapsulates the DOM <->
+ * syntax tree synchronisation algorithm used by the XML editor.
+ *
+ * Uses a real CodeMirror EditorView (backed by jsdom) so the tests exercise the
+ * real `linkSyntaxTreeWithDOM` implementation, real DOMParser, and real Lezer
+ * syntax tree — no inlined algorithm copy.
+ *
+ * The key behaviours under test:
+ *   1. Successful sync populates the last-good tree and maps and marks the
+ *      instance as synced.
+ *   2. A malformed edit is reported via `status: 'malformed'` and preserves the
+ *      previous last-good tree and maps (so navigation does not break).
+ *   3. Recovery: when the content becomes well-formed again, sync returns
+ *      `status: 'wellFormed'` and updates the maps to reflect the new text.
+ *   4. An empty document returns `status: 'empty'` and clears state.
+ *   5. Processing-instruction handling: xml-stylesheet / xml-model PIs before the
+ *      root element do not break the sync and are reported via
+ *      `getProcessingInstructions()`.
  *
  * @testCovers app/src/modules/xml-editor-dom-sync.js
  */
 
-import { test, describe } from 'node:test';
+import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
 import { JSDOM } from 'jsdom';
 
-// Mock CodeMirror structures and imports since we're testing in Node.js
-const mockLezerCommon = {
-  // Mock SyntaxNode structure
-  createMockSyntaxNode: (name, from = 0, to = 10, children = []) => ({
-    name,
-    from,
-    to,
-    firstChild: children[0] || null,
-    nextSibling: null,
-    parent: null,
-    type: { name }
-  })
-};
-
-// Mock EditorView for testing
-const createMockView = (content) => ({
-  state: {
-    doc: {
-      sliceString: (from, to) => content.substring(from, to),
-      toString: () => content
-    }
-  }
-});
-
-// Setup JSDOM environment
-const dom = new JSDOM();
+// Set up jsdom globals BEFORE importing CodeMirror (it probes for `document`).
+const dom = new JSDOM('<!DOCTYPE html><html><body><div id="editor"></div></body></html>');
+dom.window.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+dom.window.cancelAnimationFrame = (id) => clearTimeout(id);
 global.window = dom.window;
 global.document = dom.window.document;
 global.Node = dom.window.Node;
 global.DOMParser = dom.window.DOMParser;
+global.MutationObserver = dom.window.MutationObserver;
+global.requestAnimationFrame = dom.window.requestAnimationFrame;
+global.cancelAnimationFrame = dom.window.cancelAnimationFrame;
 
-// Import the function under test
-// Since we can't directly import ES modules in this test setup, we'll implement the core logic inline
-// In a real scenario, you'd set up proper ES module loading
+if (!global.window.getSelection) {
+  global.window.getSelection = () => ({
+    rangeCount: 0,
+    addRange() {},
+    removeAllRanges() {},
+    getRangeAt() { return { startContainer: null, startOffset: 0, endContainer: null, endOffset: 0 }; }
+  });
+}
+if (!global.document.getSelection) {
+  global.document.getSelection = global.window.getSelection;
+}
+if (!global.Range) global.Range = dom.window.Range;
+if (!global.StaticRange) global.StaticRange = dom.window.StaticRange;
+
+const { EditorState } = await import('@codemirror/state');
+const { EditorView } = await import('@codemirror/view');
+const { xml } = await import('@codemirror/lang-xml');
+const { ensureSyntaxTree } = await import('@codemirror/language');
+const { XmlEditorDomSync } = await import('../../../app/src/modules/xml-editor-dom-sync.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 /**
- * Simplified version of the linkSyntaxTreeWithDOM function for testing
- * This tests the core logic without CodeMirror dependencies
+ * Create a real EditorView containing the given XML.
+ * @param {string} doc
+ * @returns {EditorView}
  */
-function linkSyntaxTreeWithDOM(view, syntaxNode, domNode) {
-  const syntaxToDom = new Map();
-  const domToSyntax = new Map();
-
-  const getText = node => view.state.doc.sliceString(node.from, node.to);
-
-  function findFirstElement(node, isDOM = false) {
-    while (node) {
-      if (isDOM) {
-        if (node.nodeType === Node.ELEMENT_NODE) return node;
-      } else {
-        if (node.name === "Element") return node;
-      }
-      node = node.nextSibling;
-    }
-    return null;
-  }
-
-  function collectElementChildren(parent, isDOM = false) {
-    const elements = [];
-    let child = parent.firstChild;
-    
-    while (child) {
-      const element = findFirstElement(child, isDOM);
-      if (element) {
-        elements.push(element);
-        child = element.nextSibling;
-      } else {
-        break;
-      }
-    }
-    return elements;
-  }
-
-  function recursiveLink(syntaxNode, domNode) {
-    if (!syntaxNode || !domNode) {
-      throw new Error("Invalid arguments. Syntax node and DOM node must not be null.");
-    }
-
-    const syntaxElement = findFirstElement(syntaxNode, false);
-    const domElement = findFirstElement(domNode, true);
-
-    if (!syntaxElement || !domElement) {
-      return { syntaxToDom: new Map(), domToSyntax: new Map() };
-    }
-
-    if (syntaxElement.name !== "Element") {
-      throw new Error(`Unexpected node type: ${syntaxElement.name}. Expected "Element".`);
-    }
-
-    // Mock tag name extraction for testing
-    const syntaxTagName = syntaxElement.tagName || 'root';
-    const domTagName = domElement.tagName;
-
-    if (syntaxTagName !== domTagName) {
-      throw new Error(`Tag mismatch: Syntax tree has ${syntaxTagName}, DOM has ${domTagName}`);
-    }
-
-    syntaxToDom.set(syntaxElement.from, domElement);
-    domToSyntax.set(domElement, syntaxElement.from);
-
-    const syntaxChildren = collectElementChildren(syntaxElement, false);
-    const domChildren = collectElementChildren(domElement, true);
-
-    const minChildren = Math.min(syntaxChildren.length, domChildren.length);
-    for (let i = 0; i < minChildren; i++) {
-      const childResult = recursiveLink(syntaxChildren[i], domChildren[i]);
-      for (const [key, value] of childResult.syntaxToDom) {
-        syntaxToDom.set(key, value);
-      }
-      for (const [key, value] of childResult.domToSyntax) {
-        domToSyntax.set(key, value);
-      }
-    }
-
-    if (syntaxChildren.length > domChildren.length) {
-      const extraSyntax = syntaxChildren.slice(domChildren.length);
-      throw new Error(`Syntax tree has more child elements than the DOM tree: ${extraSyntax.length} extra`);
-    }
-    if (domChildren.length > syntaxChildren.length) {
-      const extraDOM = domChildren.slice(syntaxChildren.length);
-      throw new Error(`DOM tree has more child elements than the syntax tree: ${extraDOM.map(n => n.tagName).join(', ')}`);
-    }
-
-    return { syntaxToDom, domToSyntax };
-  }
-
-  if (syntaxNode.name !== "Document" || domNode.nodeType !== Node.DOCUMENT_NODE) {
-    throw new Error("Invalid arguments. The root syntax node must be the top Document node and the DOM node must be a document.");
-  }
-  
-  const syntaxRoot = syntaxNode.firstChild ? findFirstElement(syntaxNode.firstChild, false) : null;
-  const domRoot = domNode.firstChild ? findFirstElement(domNode.firstChild, true) : null;
-  
-  if (!syntaxRoot || !domRoot) {
-    console.warn("Could not find root elements in one or both trees");
-    return { syntaxToDom: new Map(), domToSyntax: new Map() };
-  }
-  
-  return recursiveLink(syntaxRoot, domRoot);
+function createView(doc) {
+  const parent = document.getElementById('editor');
+  parent.innerHTML = '';
+  const state = EditorState.create({
+    doc,
+    extensions: [xml()]
+  });
+  return new EditorView({ state, parent });
 }
 
-describe('XML Syntax Tree <-> DOM Synchronization', () => {
-  
-  describe('Processing Instructions Handling', () => {
-    
-    test('should handle XML with processing instructions before root element', () => {
-      const xmlWithPI = `<?xml-stylesheet type="text/xsl" href="transform.xsl"?>
-<?custom-pi data="test"?>
-<root>
-    <child>content</child>
-</root>`;
+/**
+ * Force the Lezer syntax tree to be fully parsed so that
+ * `syntaxTree(view.state)` returns a finalised tree.
+ * @param {EditorView} view
+ */
+function forceParse(view) {
+  ensureSyntaxTree(view.state, view.state.doc.length, 5000);
+}
 
-      const view = createMockView(xmlWithPI);
-      const domDoc = new DOMParser().parseFromString(xmlWithPI, "application/xml");
-      
-      // Create mock syntax tree that represents the parsed structure
-      const childSyntaxNode = {
-        name: "Element",
-        tagName: "child",
-        from: 120,
-        to: 140,
-        firstChild: null,
-        nextSibling: null
-      };
+/**
+ * Dispatch a change to the editor and force re-parse.
+ * @param {EditorView} view
+ * @param {{ from: number, to: number, insert: string }} change
+ */
+function applyChange(view, change) {
+  view.dispatch({ changes: change });
+  forceParse(view);
+}
 
-      const rootSyntaxNode = {
-        name: "Element", 
-        tagName: "root",
-        from: 100,
-        to: 150,
-        firstChild: childSyntaxNode,
-        nextSibling: null
-      };
+/**
+ * Silent logger used to keep test output clean when testing error paths.
+ */
+const silentLogger = {
+  debug() {},
+  warn() {},
+  error() {}
+};
 
-      const piNode1 = {
-        name: "ProcessingInstruction",
-        from: 0,
-        to: 40,
-        nextSibling: null
-      };
+/**
+ * Run `fn` with `console.warn` silenced. jsdom's XML parsererror format is not
+ * recognised by `parseXmlError`, which logs a `console.warn` on every malformed
+ * parse; that is expected and not a test failure — suppress it so the test
+ * output stays clean.
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @returns {Promise<T>}
+ */
+async function withSilencedConsoleWarn(fn) {
+  const original = console.warn;
+  console.warn = () => {};
+  try {
+    return await fn();
+  } finally {
+    console.warn = original;
+  }
+}
 
-      const piNode2 = {
-        name: "ProcessingInstruction", 
-        from: 41,
-        to: 95,
-        nextSibling: rootSyntaxNode
-      };
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
-      piNode1.nextSibling = piNode2;
+describe('XmlEditorDomSync', () => {
 
-      const documentSyntaxNode = {
-        name: "Document",
-        firstChild: piNode1,
-        nextSibling: null
-      };
+  describe('successful sync', () => {
 
-      // Test that synchronization works despite processing instructions
-      const result = linkSyntaxTreeWithDOM(view, documentSyntaxNode, domDoc);
-      
-      assert.ok(result.syntaxToDom instanceof Map, 'Should return syntaxToDom Map');
-      assert.ok(result.domToSyntax instanceof Map, 'Should return domToSyntax Map');
-      
-      // Verify root element is found and linked
-      const domRoot = domDoc.documentElement;
-      assert.strictEqual(domRoot.tagName, 'root', 'DOM root should be found');
-      assert.ok(result.domToSyntax.has(domRoot), 'Root element should be in domToSyntax map');
+    it('parses and links a simple well-formed document', async () => {
+      const view = createView('<root><child>hello</child></root>');
+      forceParse(view);
+      const sync = new XmlEditorDomSync({ logger: silentLogger });
+
+      const result = await sync.sync(view);
+
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(result.status, 'wellFormed');
+      assert.strictEqual(sync.isSynced(), true);
+      assert.strictEqual(sync.getLastSyncError(), null);
+
+      const tree = sync.getXmlTree();
+      assert.ok(tree, 'xml tree should be available');
+      assert.strictEqual(tree.documentElement.tagName, 'root');
+
+      const s2d = sync.getSyntaxToDom();
+      const d2s = sync.getDomToSyntax();
+      assert.ok(s2d instanceof Map && s2d.size > 0, 'syntaxToDom populated');
+      assert.ok(d2s instanceof Map && d2s.size > 0, 'domToSyntax populated');
+      assert.ok(d2s.has(tree.documentElement), 'root element linked');
     });
 
-    test('should detect processing instructions in DOM', () => {
-      const xmlWithPI = `<?xml-stylesheet href="style.xsl"?>
-<?custom-instruction data="value"?>
-<root><child/></root>`;
+    it('populates editor content cache', async () => {
+      const text = '<root><a/></root>';
+      const view = createView(text);
+      forceParse(view);
+      const sync = new XmlEditorDomSync({ logger: silentLogger });
 
-      const domDoc = new DOMParser().parseFromString(xmlWithPI, "application/xml");
-      
-      const processingInstructions = [];
-      for (let i = 0; i < domDoc.childNodes.length; i++) {
-        const node = domDoc.childNodes[i];
-        if (node.nodeType === Node.PROCESSING_INSTRUCTION_NODE) {
-          // @ts-ignore - node is a ProcessingInstruction when nodeType matches
-          const piNode = node;
-          processingInstructions.push({
-            target: piNode.target,
-            data: piNode.data,
-            position: i
-          });
-        }
-      }
+      await sync.sync(view);
 
-      assert.strictEqual(processingInstructions.length, 2, 'Should find 2 processing instructions');
-      assert.strictEqual(processingInstructions[0].target, 'xml-stylesheet', 'First PI should be stylesheet');
-      assert.strictEqual(processingInstructions[1].target, 'custom-instruction', 'Second PI should be custom instruction');
+      assert.strictEqual(sync.getEditorContent(), text);
     });
 
-    test('should handle mixed content (PIs, comments, elements)', () => {
-      const mixedXml = `<!-- A comment -->
-<?xml-stylesheet href="style.xsl"?>  
-<!-- Another comment -->
-<?another-pi?>
-<root>
-    <child>content</child>
-</root>`;
+    it('handles nested elements correctly', async () => {
+      const view = createView('<a><b><c><d/></c></b></a>');
+      forceParse(view);
+      const sync = new XmlEditorDomSync({ logger: silentLogger });
 
-      const domDoc = new DOMParser().parseFromString(mixedXml, "application/xml");
-      
-      let elementCount = 0;
-      let piCount = 0;
-      let commentCount = 0;
-      
-      for (let i = 0; i < domDoc.childNodes.length; i++) {
-        const node = domDoc.childNodes[i];
-        if (node.nodeType === Node.ELEMENT_NODE) elementCount++;
-        else if (node.nodeType === Node.PROCESSING_INSTRUCTION_NODE) piCount++;
-        else if (node.nodeType === Node.COMMENT_NODE) commentCount++;
-      }
-      
-      assert.strictEqual(elementCount, 1, 'Should find exactly one root element');
-      assert.strictEqual(piCount, 2, 'Should find exactly two processing instructions');
-      assert.strictEqual(commentCount, 2, 'Should find exactly two comments');
-      
-      // Test that root element can still be found
-      const rootElement = domDoc.documentElement;
-      assert.strictEqual(rootElement.tagName, 'root', 'Should find root element despite mixed content');
-    });
+      const result = await sync.sync(view);
 
-    test('should handle real-world XML with xml-model processing instruction', () => {
-      const realWorldXml = `<?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://raw.githubusercontent.com/kermitt2/grobid/refs/heads/master/grobid-home/schemas/rng/Grobid.rng" 
-              type="application/xml" 
-              schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title>Test Document</title>
-            </titleStmt>
-        </fileDesc>
-    </teiHeader>
-    <text>
-        <body>
-            <p>Content</p>
-        </body>
-    </text>
-</TEI>`;
-
-      const view = createMockView(realWorldXml);
-      const domDoc = new DOMParser().parseFromString(realWorldXml, "application/xml");
-      
-      // Verify parsing succeeded
-      assert.ok(!domDoc.querySelector("parsererror"), 'XML should parse without errors');
-      
-      // Count different node types
-      let elementCount = 0;
-      let piCount = 0;
-      let textNodes = 0;
-      
-      for (let i = 0; i < domDoc.childNodes.length; i++) {
-        const node = domDoc.childNodes[i];
-        if (node.nodeType === Node.ELEMENT_NODE) {
-          elementCount++;
-        } else if (node.nodeType === Node.PROCESSING_INSTRUCTION_NODE) {
-          piCount++;
-          // @ts-ignore - node is a ProcessingInstruction when nodeType matches
-          const piNode = node;
-          console.log(`Found PI: ${piNode.target} with data: ${piNode.data.substring(0, 50)}...`);
-        } else if (node.nodeType === Node.TEXT_NODE) {
-          textNodes++;
-        }
-      }
-      
-      // Should find the xml-model processing instruction (xml declaration is not counted as PI)
-      assert.strictEqual(piCount, 1, 'Should find exactly one processing instruction (xml-model)');
-      assert.strictEqual(elementCount, 1, 'Should find exactly one root element');
-      
-      // Verify root element is TEI
-      const rootElement = domDoc.documentElement;
-      assert.strictEqual(rootElement.tagName, 'TEI', 'Root element should be TEI');
-      assert.strictEqual(rootElement.namespaceURI, 'http://www.tei-c.org/ns/1.0', 'Should have correct namespace');
-      
-      // Test synchronization with mock syntax tree that matches the DOM structure
-      const pElement = {
-        name: "Element",
-        tagName: "p",
-        from: 540,
-        to: 550,
-        firstChild: null,
-        nextSibling: null
-      };
-
-      const bodyElement = {
-        name: "Element",
-        tagName: "body",
-        from: 520,
-        to: 560,
-        firstChild: pElement,
-        nextSibling: null
-      };
-
-      const textElement = {
-        name: "Element", 
-        tagName: "text",
-        from: 500,
-        to: 570,
-        firstChild: bodyElement,
-        nextSibling: null
-      };
-
-      const titleElement = {
-        name: "Element",
-        tagName: "title",
-        from: 300,
-        to: 315,
-        firstChild: null,
-        nextSibling: null
-      };
-
-      const titleStmtElement = {
-        name: "Element",
-        tagName: "titleStmt",
-        from: 280,
-        to: 320,
-        firstChild: titleElement,
-        nextSibling: null
-      };
-
-      const fileDescElement = {
-        name: "Element",
-        tagName: "fileDesc", 
-        from: 260,
-        to: 350,
-        firstChild: titleStmtElement,
-        nextSibling: null
-      };
-
-      const teiHeaderElement = {
-        name: "Element",
-        tagName: "teiHeader", 
-        from: 240,
-        to: 370,
-        firstChild: fileDescElement,
-        nextSibling: textElement
-      };
-
-      const teiRootElement = {
-        name: "Element",
-        tagName: "TEI",
-        from: 200,
-        to: 580,
-        firstChild: teiHeaderElement,
-        nextSibling: null
-      };
-
-      const piNode = {
-        name: "ProcessingInstruction",
-        from: 0,
-        to: 149,
-        nextSibling: teiRootElement
-      };
-
-      const documentSyntaxNode = {
-        name: "Document",
-        firstChild: piNode,
-        nextSibling: null
-      };
-
-      // Test that synchronization works despite processing instructions
-      const result = linkSyntaxTreeWithDOM(view, documentSyntaxNode, domDoc);
-      
-      assert.ok(result.syntaxToDom instanceof Map, 'Should return syntaxToDom Map');
-      assert.ok(result.domToSyntax instanceof Map, 'Should return domToSyntax Map');
-      assert.ok(result.domToSyntax.has(rootElement), 'TEI root element should be in domToSyntax map');
+      assert.strictEqual(result.ok, true);
+      const tree = sync.getXmlTree();
+      // There are 4 elements (a/b/c/d) — each should be in the domToSyntax map.
+      assert.strictEqual(sync.getDomToSyntax().size, 4);
+      assert.strictEqual(tree.documentElement.tagName, 'a');
     });
   });
 
-  describe('Basic Synchronization', () => {
-    
-    test('should synchronize simple XML without processing instructions', () => {
-      const simpleXml = `<root><child>content</child></root>`;
-      
-      const view = createMockView(simpleXml);
-      const domDoc = new DOMParser().parseFromString(simpleXml, "application/xml");
-      
-      const childSyntaxNode = {
-        name: "Element",
-        tagName: "child", 
-        from: 6,
-        to: 26,
-        firstChild: null,
-        nextSibling: null
-      };
+  describe('malformed input preserves last-good tree', () => {
 
-      const rootSyntaxNode = {
-        name: "Element",
-        tagName: "root",
-        from: 0,
-        to: 33,
-        firstChild: childSyntaxNode,
-        nextSibling: null
-      };
+    it('reports malformed status without discarding previous tree', async () => {
+      await withSilencedConsoleWarn(async () => {
+        const view = createView('<root><child>hello</child></root>');
+        forceParse(view);
+        const sync = new XmlEditorDomSync({ logger: silentLogger });
 
-      const documentSyntaxNode = {
-        name: "Document",
-        firstChild: rootSyntaxNode,
-        nextSibling: null
-      };
+        // First sync — valid document populates the last-good tree.
+        const firstResult = await sync.sync(view);
+        assert.strictEqual(firstResult.status, 'wellFormed');
+        const firstTree = sync.getXmlTree();
+        const firstMap = sync.getDomToSyntax();
+        assert.ok(firstTree);
+        assert.ok(firstMap);
 
-      const result = linkSyntaxTreeWithDOM(view, documentSyntaxNode, domDoc);
-      
-      assert.ok(result.syntaxToDom.size > 0, 'Should create mappings');
-      assert.ok(result.domToSyntax.size > 0, 'Should create reverse mappings');
+        // Break the document by deleting the closing `>` of the opening tag.
+        // "<root><child>hello</child></root>" → "<root<child>hello</child></root>"
+        applyChange(view, { from: 5, to: 6, insert: '' });
+        const secondResult = await sync.sync(view);
+
+        assert.strictEqual(secondResult.ok, false);
+        assert.strictEqual(secondResult.status, 'malformed');
+        assert.ok(secondResult.diagnostic, 'diagnostic should be reported');
+        assert.strictEqual(typeof secondResult.diagnostic.message, 'string');
+        assert.strictEqual(sync.isSynced(), false);
+
+        // The last-good tree and maps MUST be preserved.
+        assert.strictEqual(
+          sync.getXmlTree(),
+          firstTree,
+          'last-good xml tree should be preserved after malformed edit'
+        );
+        assert.strictEqual(
+          sync.getDomToSyntax(),
+          firstMap,
+          'last-good domToSyntax map should be preserved after malformed edit'
+        );
+
+        const err = sync.getLastSyncError();
+        assert.ok(err, 'lastSyncError should be recorded');
+        assert.strictEqual(err.stage, 'parse');
+      });
     });
 
-    test('should throw error on tag mismatch', () => {
-      const xml = `<root></root>`;
-      
-      const view = createMockView(xml);
-      const domDoc = new DOMParser().parseFromString(xml, "application/xml");
-      
-      const rootSyntaxNode = {
-        name: "Element",
-        tagName: "different", // Intentional mismatch
-        from: 0,
-        to: 13,
-        firstChild: null,
-        nextSibling: null
-      };
+    it('recovers when the document becomes well-formed again', async () => {
+      await withSilencedConsoleWarn(async () => {
+        const view = createView('<root><child>hello</child></root>');
+        forceParse(view);
+        const sync = new XmlEditorDomSync({ logger: silentLogger });
 
-      const documentSyntaxNode = {
-        name: "Document", 
-        firstChild: rootSyntaxNode,
-        nextSibling: null
-      };
+        await sync.sync(view);
 
-      assert.throws(
-        () => linkSyntaxTreeWithDOM(view, documentSyntaxNode, domDoc),
-        /Tag mismatch/,
-        'Should throw error on tag name mismatch'
-      );
+        // Break it.
+        applyChange(view, { from: 5, to: 6, insert: '' });
+        const malformed = await sync.sync(view);
+        assert.strictEqual(malformed.status, 'malformed');
+        assert.strictEqual(sync.isSynced(), false);
+
+        // Re-insert the `>` to repair the document.
+        applyChange(view, { from: 5, to: 5, insert: '>' });
+        const recovered = await sync.sync(view);
+
+        assert.strictEqual(recovered.ok, true);
+        assert.strictEqual(recovered.status, 'wellFormed');
+        assert.strictEqual(sync.isSynced(), true);
+        assert.strictEqual(sync.getLastSyncError(), null);
+        const tree = sync.getXmlTree();
+        assert.ok(tree);
+        assert.strictEqual(tree.documentElement.tagName, 'root');
+      });
+    });
+
+    it('keeps maps available for navigation queries while malformed', async () => {
+      await withSilencedConsoleWarn(async () => {
+        const view = createView('<root><child>hello</child></root>');
+        forceParse(view);
+        const sync = new XmlEditorDomSync({ logger: silentLogger });
+
+        await sync.sync(view);
+        const preserved = sync.getXmlTree();
+
+        // Break the document.
+        applyChange(view, { from: 5, to: 6, insert: '' });
+        await sync.sync(view);
+
+        // Navigation-style queries still work off the last-good tree.
+        assert.ok(sync.getXmlTree() === preserved);
+        const rootEl = sync.getXmlTree().documentElement;
+        assert.ok(sync.getDomToSyntax().has(rootEl));
+      });
     });
   });
 
-  describe('Edge Cases', () => {
-    
-    test('should handle empty documents gracefully', () => {
-      const emptyXml = `<root></root>`;
-      
-      const view = createMockView(emptyXml);
-      const domDoc = new DOMParser().parseFromString(emptyXml, "application/xml");
-      
-      const rootSyntaxNode = {
-        name: "Element",
-        tagName: "root",
-        from: 0,
-        to: 13,
-        firstChild: null,
-        nextSibling: null
-      };
+  describe('empty document', () => {
 
-      const documentSyntaxNode = {
-        name: "Document",
-        firstChild: rootSyntaxNode,
-        nextSibling: null
-      };
+    it('returns status: empty and clears state', async () => {
+      const view = createView('<root/>');
+      forceParse(view);
+      const sync = new XmlEditorDomSync({ logger: silentLogger });
 
-      const result = linkSyntaxTreeWithDOM(view, documentSyntaxNode, domDoc);
-      
-      assert.ok(result.syntaxToDom instanceof Map, 'Should return Map for empty document');
-      assert.ok(result.domToSyntax instanceof Map, 'Should return reverse Map for empty document');
+      await sync.sync(view);
+      assert.ok(sync.getXmlTree());
+
+      // Clear editor content.
+      view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: '' } });
+      forceParse(view);
+
+      const result = await sync.sync(view);
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.status, 'empty');
+      assert.strictEqual(sync.getXmlTree(), null);
+      assert.strictEqual(sync.getDomToSyntax(), null);
+      assert.strictEqual(sync.getSyntaxToDom(), null);
+      assert.strictEqual(sync.getProcessingInstructions().length, 0);
+      assert.strictEqual(sync.isSynced(), false);
+    });
+  });
+
+  describe('clear()', () => {
+
+    it('resets all state', async () => {
+      const view = createView('<root><a/></root>');
+      forceParse(view);
+      const sync = new XmlEditorDomSync({ logger: silentLogger });
+
+      await sync.sync(view);
+      assert.ok(sync.getXmlTree());
+      assert.strictEqual(sync.isSynced(), true);
+
+      sync.clear();
+
+      assert.strictEqual(sync.getXmlTree(), null);
+      assert.strictEqual(sync.getSyntaxTree(), null);
+      assert.strictEqual(sync.getDomToSyntax(), null);
+      assert.strictEqual(sync.getSyntaxToDom(), null);
+      assert.strictEqual(sync.getEditorContent(), '');
+      assert.strictEqual(sync.isSynced(), false);
+      assert.strictEqual(sync.getLastSyncError(), null);
+      assert.strictEqual(sync.getProcessingInstructions().length, 0);
+    });
+  });
+
+  describe('processing instructions', () => {
+
+    it('detects PIs before the root element', async () => {
+      const text =
+        '<?xml-stylesheet href="style.xsl"?>' +
+        '<?custom-pi data="test"?>' +
+        '<root><child>content</child></root>';
+      const view = createView(text);
+      forceParse(view);
+      const sync = new XmlEditorDomSync({ logger: silentLogger });
+
+      const result = await sync.sync(view);
+      assert.strictEqual(result.status, 'wellFormed');
+
+      const pis = sync.getProcessingInstructions();
+      assert.strictEqual(pis.length, 2);
+      assert.strictEqual(pis[0].target, 'xml-stylesheet');
+      assert.strictEqual(pis[1].target, 'custom-pi');
     });
 
-    test('should handle documents with only processing instructions', () => {
-      const piOnlyXml = `<?xml-stylesheet href="style.xsl"?><?custom-pi?>`;
-      
-      const view = createMockView(piOnlyXml + '<root></root>'); // Add root for valid XML
-      const domDoc = new DOMParser().parseFromString(piOnlyXml + '<root></root>', "application/xml");
-      
-      // Mock syntax tree with only PIs and a root
-      const rootSyntaxNode = {
-        name: "Element",
-        tagName: "root",
-        from: 55,
-        to: 68,
-        firstChild: null,
-        nextSibling: null
-      };
+    it('handles real-world TEI xml-model PI', async () => {
+      const text =
+        '<?xml-model href="https://example.org/tei.rng" ' +
+        'type="application/xml" ' +
+        'schematypens="http://relaxng.org/ns/structure/1.0"?>' +
+        '<TEI xmlns="http://www.tei-c.org/ns/1.0">' +
+        '<teiHeader><fileDesc><titleStmt><title>T</title></titleStmt>' +
+        '<publicationStmt><p>P</p></publicationStmt>' +
+        '<sourceDesc><p>S</p></sourceDesc></fileDesc></teiHeader>' +
+        '<text><body><p>Content</p></body></text>' +
+        '</TEI>';
+      const view = createView(text);
+      forceParse(view);
+      const sync = new XmlEditorDomSync({ logger: silentLogger });
 
-      const piNode = {
-        name: "ProcessingInstruction",
-        from: 0,
-        to: 54,
-        nextSibling: rootSyntaxNode
-      };
+      const result = await sync.sync(view);
 
-      const documentSyntaxNode = {
-        name: "Document",
-        firstChild: piNode,
-        nextSibling: null
-      };
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(result.status, 'wellFormed');
+      const tree = sync.getXmlTree();
+      assert.strictEqual(tree.documentElement.tagName, 'TEI');
+      const pis = sync.getProcessingInstructions();
+      assert.strictEqual(pis.length, 1);
+      assert.strictEqual(pis[0].target, 'xml-model');
+    });
 
-      const result = linkSyntaxTreeWithDOM(view, documentSyntaxNode, domDoc);
-      
-      // Should still work - finds the root element despite PIs
-      assert.ok(result.syntaxToDom instanceof Map, 'Should handle PI-only start');
-      assert.ok(result.domToSyntax.has(domDoc.documentElement), 'Should map root element');
+    it('handles mixed content (comments + PIs + elements)', async () => {
+      const text =
+        '<!-- leading comment -->' +
+        '<?xml-stylesheet href="s.xsl"?>' +
+        '<!-- another comment -->' +
+        '<root><c/></root>';
+      const view = createView(text);
+      forceParse(view);
+      const sync = new XmlEditorDomSync({ logger: silentLogger });
+
+      const result = await sync.sync(view);
+      assert.strictEqual(result.status, 'wellFormed');
+      assert.strictEqual(sync.getProcessingInstructions().length, 1);
+      assert.strictEqual(sync.getXmlTree().documentElement.tagName, 'root');
     });
   });
 });
-
-// Helper function to run tests
-if (import.meta.url === `file://${process.argv[1]}`) {
-  console.log('🧪 Running XML Synchronization Algorithm Tests...\n');
-}


### PR DESCRIPTION
Auto-save silently bailed when the editor buffer was not well-formed, leaving users with no indication that their edits were not being saved. Extended edits against a malformed buffer (e.g. a mismatched closing tag caused by a prior keystroke) could be lost on navigation or reload.

- Extract DOM/syntax-tree sync into XmlEditorDomSync; preserve the last-known-good xmlTree and maps when parsing or linking fails, and expose isSynced() so callers that mutate the DOM (e.g. edit artifact label) can bail out safely.
- Add XmlEditorDraftStore: per-file localStorage drafts (2 MB cap) with adaptive throttle (500 ms well-formed, 200 ms malformed), flushed immediately when save is blocked and on beforeunload.
- Surface unsaved state in the header statusbar and browser title; show a single toast when auto-save first becomes blocked instead of logging at debug level. Offer draft restore on document load.
- Fix markAsClean() race: compare documentVersion before and after the server round-trip and only clear the dirty flag when the user did not type during the save.
- beforeunload guard blocks navigation when the editor is dirty or save is blocked.
- filedata.saveXml throws a dedicated NoValidXmlError.
- Clean up linkSyntaxTreeWithDOM: split the polymorphic sibling helpers into typed ones, replace the array-materialising child pairing with a two-cursor walk, and remove dead branches. Same behaviour, lower per-element allocations.
- Rewrite sync-algorithm.test.js against the real XmlEditorDomSync.

Fixes #358