### PR TITLE
feat: add batch move/copy documents from file drawer (closes #400)

### DIFF
--- a/app/src/modules/api-client-v1.js
+++ b/app/src/modules/api-client-v1.js
@@ -205,14 +205,12 @@
 /**
  * @typedef {Object} CopyFilesRequest
  * @property {string} pdf_id
- * @property {string} xml_id
  * @property {string} destination_collection
  */
 
 /**
  * @typedef {Object} CopyFilesResponse
  * @property {string} new_pdf_id
- * @property {string} new_xml_id
  */
 
 /**
@@ -439,14 +437,12 @@
 /**
  * @typedef {Object} MoveFilesRequest
  * @property {string} pdf_id
- * @property {string} xml_id
  * @property {string} destination_collection
  */
 
 /**
  * @typedef {Object} MoveFilesResponse
  * @property {string} new_pdf_id
- * @property {string} new_xml_id
  */
 
 /**

--- a/app/src/modules/codemirror/codemirror-utils.js
+++ b/app/src/modules/codemirror/codemirror-utils.js
@@ -612,3 +612,59 @@ export function resolveDeduplicated(data) {
 
   return finalResolved;
 }
+
+/**
+ * Finds the element that actually vertically scrolls the CodeMirror editor content.
+ * When the layout does not constrain CM's height, cm-scroller expands to its content
+ * and never scrolls; a parent element with overflow:auto/scroll does the scrolling instead.
+ * @param {EditorView} view
+ * @returns {Element|null}
+ */
+export function findCmScrollContainer(view) {
+  const cmScrollEl = view.scrollDOM
+  if (cmScrollEl.scrollHeight > cmScrollEl.clientHeight + 1) return cmScrollEl
+  let el = /** @type {Element|null} */ (cmScrollEl.parentElement)
+  while (el && el !== document.documentElement) {
+    const overflowY = getComputedStyle(el).overflowY
+    if (overflowY === 'auto' || overflowY === 'scroll') return el
+    el = el.parentElement
+  }
+  return null
+}
+
+/**
+ * Returns the document character position of the first visible line in the editor.
+ * Uses getBoundingClientRect to compute how many pixels of CM content are hidden above
+ * the visible area, then maps that pixel height to a character position via lineBlockAtHeight.
+ * Works correctly when the actual scroll container is an ancestor of cm-scroller
+ * (i.e. cm-scroller is unconstrained and does not itself scroll).
+ * @param {EditorView} view
+ * @param {Element} scrollContainer The element returned by {@link findCmScrollContainer}
+ * @returns {number}
+ */
+export function getFirstVisibleCharacter(view, scrollContainer) {
+  const cmRect = view.scrollDOM.getBoundingClientRect()
+  const containerRect = scrollContainer.getBoundingClientRect()
+  const hiddenAbove = Math.max(0, containerRect.top - cmRect.top)
+  return view.lineBlockAtHeight(hiddenAbove).from
+}
+
+/**
+ * Scrolls the given document character position to the top of the visible editor area
+ * by directly adjusting the scroll container's scrollTop.
+ * Computes the CM editor's absolute offset within the scrollable content at call time,
+ * so it works even when the layout has changed since the position was captured (e.g. after
+ * header fold/unfold or extension reconfigure).
+ * Must be called after CM has re-rendered so that lineBlockAt reflects the current layout.
+ * @param {EditorView} view
+ * @param {Element} scrollContainer The element returned by {@link findCmScrollContainer}
+ * @param {number} pos The document character position to scroll to the top
+ */
+export function scrollCharacterToTop(view, scrollContainer, pos) {
+  const block = view.lineBlockAt(pos)
+  const cmRect = view.scrollDOM.getBoundingClientRect()
+  const containerRect = scrollContainer.getBoundingClientRect()
+  // Absolute offset of the CM editor's top within the scrollable content
+  const cmAbsoluteTop = scrollContainer.scrollTop + (cmRect.top - containerRect.top)
+  scrollContainer.scrollTop = cmAbsoluteTop + block.top
+}

--- a/app/src/modules/codemirror/editor-themes.js
+++ b/app/src/modules/codemirror/editor-themes.js
@@ -1,0 +1,104 @@
+/**
+ * @import {Extension} from '@codemirror/state'
+ */
+
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { EditorView } from "@codemirror/view";
+import { tags } from "@lezer/highlight";
+
+/**
+ * @typedef {object} EditorTheme
+ * @property {string} id - Unique identifier used for persistence
+ * @property {string} label - Display label shown in the theme menu
+ * @property {Extension[]} extensions - CodeMirror extensions to load into the theme Compartment
+ */
+
+const defaultHighlight = HighlightStyle.define([
+  { tag: tags.tagName, color: "#0000c0", fontWeight: "bold" },
+  { tag: tags.angleBracket, color: "#0000c0" },
+  { tag: tags.attributeName, color: "#7d0000" },
+  { tag: tags.attributeValue, color: "#036103" },
+  { tag: tags.comment, color: "#808080", fontStyle: "italic" },
+  { tag: tags.processingInstruction, color: "#9b2d9b" },
+  { tag: tags.operator, color: "#555" },
+]);
+
+const darkHighlight = HighlightStyle.define([
+  { tag: tags.tagName, color: "#89b4fa", fontWeight: "bold" },
+  { tag: tags.angleBracket, color: "#89b4fa" },
+  { tag: tags.attributeName, color: "#f38ba8" },
+  { tag: tags.attributeValue, color: "#a6e3a1" },
+  { tag: tags.comment, color: "#6c7086", fontStyle: "italic" },
+  { tag: tags.processingInstruction, color: "#cba6f7" },
+  { tag: tags.operator, color: "#a6adc8" },
+]);
+
+const colorBlindHighlight = HighlightStyle.define([
+  { tag: tags.tagName, color: "#648fff", fontWeight: "bold" },
+  { tag: tags.angleBracket, color: "#648fff" },
+  { tag: tags.attributeName, color: "#dc267f" },
+  { tag: tags.attributeValue, color: "#009e73" },
+  { tag: tags.comment, color: "#767676", fontStyle: "italic" },
+  { tag: tags.processingInstruction, color: "#785ef0" },
+  { tag: tags.operator, color: "#555" },
+]);
+
+const highContrastHighlight = HighlightStyle.define([
+  { tag: tags.tagName, color: "#0000ff", fontWeight: "bold" },
+  { tag: tags.angleBracket, color: "#0000ff" },
+  { tag: tags.attributeName, color: "#cc0000" },
+  { tag: tags.attributeValue, color: "#006600" },
+  { tag: tags.comment, color: "#595959", fontStyle: "italic" },
+  { tag: tags.processingInstruction, color: "#7b00a3" },
+  { tag: tags.operator, color: "#333" },
+]);
+
+const darkViewTheme = EditorView.theme({
+  "&": { backgroundColor: "#1e1e2e", color: "#cdd6f4" },
+  ".cm-content": { caretColor: "#cdd6f4" },
+  ".cm-cursor": { borderLeftColor: "#cdd6f4" },
+  ".cm-gutters": { backgroundColor: "#181825", color: "#6c7086", border: "none" },
+  ".cm-activeLineGutter": { backgroundColor: "#1e1e2e" },
+  ".cm-activeLine": { backgroundColor: "#2a2a3d" },
+  ".cm-selectionBackground": { backgroundColor: "#45475a" },
+  "&.cm-focused .cm-selectionBackground": { backgroundColor: "#45475a" },
+  ".cm-foldPlaceholder": { backgroundColor: "#313244", color: "#cdd6f4", border: "none" },
+}, { dark: true });
+
+const lightViewTheme = EditorView.theme({
+  "&": { backgroundColor: "#ffffff", color: "#1e1e1e" },
+  ".cm-gutters": { backgroundColor: "#f5f5f5", color: "#999", border: "none" },
+});
+
+/** @type {EditorTheme[]} */
+export const THEMES = [
+  {
+    id: "default",
+    label: "Default (light)",
+    extensions: [lightViewTheme, syntaxHighlighting(defaultHighlight)],
+  },
+  {
+    id: "dark",
+    label: "Dark",
+    extensions: [darkViewTheme, syntaxHighlighting(darkHighlight)],
+  },
+  {
+    id: "colorBlind",
+    label: "Color-blind friendly",
+    extensions: [lightViewTheme, syntaxHighlighting(colorBlindHighlight)],
+  },
+  {
+    id: "highContrast",
+    label: "High contrast",
+    extensions: [lightViewTheme, syntaxHighlighting(highContrastHighlight)],
+  },
+];
+
+/**
+ * Look up a theme bundle by id, falling back to default.
+ * @param {string} id
+ * @returns {EditorTheme}
+ */
+export function getTheme(id) {
+  return THEMES.find(t => t.id === id) ?? THEMES[0];
+}

--- a/app/src/modules/panels/widgets/status-switch.js
+++ b/app/src/modules/panels/widgets/status-switch.js
@@ -10,6 +10,7 @@ class StatusSwitch extends HTMLElement {
 
   constructor() {
     super();
+    this._programmaticChecked = false;
     this.attachShadow({ mode: 'open' });
     this.render();
   }
@@ -20,7 +21,9 @@ class StatusSwitch extends HTMLElement {
     this.setupEventListeners();
   }
 
-  attributeChangedCallback() {
+  attributeChangedCallback(name) {
+    // Skip re-render for programmatic checked changes; the setter updates sl-switch directly.
+    if (name === 'checked' && this._programmaticChecked) return;
     this.render();
     if (this.isConnected) {
       this.updateHostProperties();
@@ -135,11 +138,17 @@ class StatusSwitch extends HTMLElement {
   }
 
   set checked(value) {
+    // Use flag so attributeChangedCallback skips render; update the inner sl-switch directly
+    // to avoid destroying/recreating it, which causes spurious sl-change events from Shoelace.
+    this._programmaticChecked = true;
     if (value) {
       this.setAttribute('checked', '');
     } else {
       this.removeAttribute('checked');
     }
+    this._programmaticChecked = false;
+    const slSwitch = this.shadowRoot?.querySelector('sl-switch');
+    if (slSwitch) slSwitch.checked = Boolean(value);
   }
 
   get disabled() {

--- a/app/src/modules/xmleditor.js
+++ b/app/src/modules/xmleditor.js
@@ -962,7 +962,6 @@ export class XMLEditor extends EventEmitter {
       throw new Error("XPath is not provided.");
     }
     xpath = `count(${xpath})`
-
     return xmlTree.evaluate(xpath, xmlTree, this.namespaceResolver, XPathResult.NUMBER_TYPE, null).numberValue;
   }
 

--- a/app/src/modules/xmleditor.js
+++ b/app/src/modules/xmleditor.js
@@ -45,7 +45,7 @@ import { EditorState, EditorSelection, Compartment, Transaction, StateEffect } f
 import { unifiedMergeView, goToNextChunk, goToPreviousChunk, getChunks, rejectChunk } from "@codemirror/merge"
 import { EditorView, keymap, lineNumbers, highlightActiveLineGutter, highlightSpecialChars, drawSelection, dropCursor, crosshairCursor, highlightActiveLine, rectangularSelection } from "@codemirror/view"
 import { xml, xmlLanguage } from "@codemirror/lang-xml";
-import { syntaxTree, syntaxParserRunning, indentUnit, foldInside, foldEffect, unfoldEffect, foldGutter, foldKeymap, indentOnInput, syntaxHighlighting, defaultHighlightStyle, bracketMatching } from "@codemirror/language"
+import { syntaxTree, syntaxParserRunning, indentUnit, foldInside, foldEffect, unfoldEffect, foldGutter, foldKeymap, indentOnInput, syntaxHighlighting, bracketMatching } from "@codemirror/language"
 import { history, historyKeymap, defaultKeymap, indentWithTab } from "@codemirror/commands"
 import { autocompletion, closeBrackets, closeBracketsKeymap, completionKeymap } from "@codemirror/autocomplete"
 import { highlightSelectionMatches, searchKeymap } from "@codemirror/search"
@@ -58,6 +58,10 @@ import { EventEmitter } from './event-emitter.js';
 import { xmlTagSync } from "./codemirror/xml-tag-sync.js";
 import { createCompletionSource } from './codemirror/autocomplete.js';
 import { XmlEditorDomSync } from './xml-editor-dom-sync.js';
+import { getTheme } from './codemirror/editor-themes.js';
+/**
+ * @import {EditorTheme} from './codemirror/editor-themes.js'
+ */
 
 /**
  * An XML editor based on the CodeMirror editor, which keeps the CodeMirror syntax tree and a DOM XML 
@@ -166,6 +170,7 @@ export class XMLEditor extends EventEmitter {
   #indentationCompartment = new Compartment()
   #readOnlyCompartment = new Compartment()
   #xmlTagSyncCompartment = new Compartment()
+  #themeCompartment = new Compartment()
 
 
   /**
@@ -198,7 +203,7 @@ export class XMLEditor extends EventEmitter {
       dropCursor(),
       EditorState.allowMultipleSelections.of(true),
       indentOnInput(),
-      syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+      this.#themeCompartment.of(getTheme('default').extensions),
       bracketMatching(),
       closeBrackets(),
       autocompletion(),
@@ -801,6 +806,16 @@ export class XMLEditor extends EventEmitter {
     });
     requestAnimationFrame(() => {
       this.#view.scrollDOM.scrollLeft = 0;
+    });
+  }
+
+  /**
+   * Replaces the active editor theme bundle.
+   * @param {EditorTheme} theme
+   */
+  setTheme(theme) {
+    this.#view.dispatch({
+      effects: this.#themeCompartment.reconfigure(theme.extensions)
     });
   }
 

--- a/app/src/plugins/client.js
+++ b/app/src/plugins/client.js
@@ -453,31 +453,27 @@ async function state() {
 
 
 /**
- * Moves the given files to a new collection
- * @param {string} pdf - PDF file ID
- * @param {string} xml - XML file ID
+ * Moves the given PDF (and all its associated TEI files) to a new collection
+ * @param {string} pdf - PDF file stable_id
  * @param {string} destinationCollection - Destination collection ID
- * @returns {Promise<{new_pdf_id: string, new_xml_id: string}>}
+ * @returns {Promise<{new_pdf_id: string}>}
  */
-async function moveFiles(pdf, xml, destinationCollection) {
+async function moveFiles(pdf, destinationCollection) {
   return await apiClient.filesMove({
     pdf_id: pdf,
-    xml_id: xml,
     destination_collection: destinationCollection
   });
 }
 
 /**
- * Copies the given files to an additional collection
- * @param {string} pdf - PDF file ID
- * @param {string} xml - XML file ID
+ * Copies the given PDF (and all its associated TEI files) to an additional collection
+ * @param {string} pdf - PDF file stable_id
  * @param {string} destinationCollection - Destination collection ID
- * @returns {Promise<{new_pdf_id: string, new_xml_id: string}>}
+ * @returns {Promise<{new_pdf_id: string}>}
  */
-async function copyFiles(pdf, xml, destinationCollection) {
+async function copyFiles(pdf, destinationCollection) {
   return await apiClient.filesCopy({
     pdf_id: pdf,
-    xml_id: xml,
     destination_collection: destinationCollection
   });
 }

--- a/app/src/plugins/file-selection-drawer.js
+++ b/app/src/plugins/file-selection-drawer.js
@@ -235,6 +235,8 @@ class FileSelectionDrawerPlugin extends Plugin {
     this.#logger.debug("Closing file selection drawer");
     this.#selectedCollections.clear();
     this.#updateExportButtonState();
+    this.#selectedDocuments.clear();
+    this.#updateMoveCopyButtonState();
     this.#drawerUi.hide();
   }
 
@@ -856,9 +858,24 @@ class FileSelectionDrawerPlugin extends Plugin {
           this.#selectedCollections.delete(collectionName);
         }
       }
+      // Sync document checkboxes — programmatic, does NOT fire sl-change
+      const pdfItems = item.querySelectorAll('.pdf-item');
+      pdfItems.forEach(pdfItem => {
+        const pdfCheckbox = /** @type {SlCheckbox} */ (pdfItem.querySelector('sl-checkbox'));
+        const pdfId = /** @type {HTMLElement} */ (pdfItem).dataset.hash;
+        if (pdfCheckbox && pdfId) {
+          pdfCheckbox.checked = checked;
+          if (checked) {
+            this.#selectedDocuments.add(pdfId);
+          } else {
+            this.#selectedDocuments.delete(pdfId);
+          }
+        }
+      });
     });
 
     this.#updateExportButtonState();
+    this.#updateMoveCopyButtonState();
   }
 
   // TODO #368: Replace sessionStorage with a generic UI state persistence mechanism
@@ -1213,35 +1230,38 @@ class FileSelectionDrawerPlugin extends Plugin {
     let successCount = 0;
     const errors = [];
 
-    for (const pdfId of pdfIds) {
-      for (const collectionId of targetCollections) {
-        try {
-          if (action === 'move') {
-            await this.#client.moveFiles(pdfId, collectionId);
-          } else {
-            await this.#client.copyFiles(pdfId, collectionId);
+    try {
+      for (const pdfId of pdfIds) {
+        for (const collectionId of targetCollections) {
+          try {
+            if (action === 'move') {
+              await this.#client.moveFiles(pdfId, collectionId);
+            } else {
+              await this.#client.copyFiles(pdfId, collectionId);
+            }
+            successCount++;
+          } catch (error) {
+            errors.push({ pdfId, collectionId, error: String(error) });
+            this.#logger.error(`Failed to ${action} ${pdfId} to ${collectionId}: ${error}`);
           }
-          successCount++;
-        } catch (error) {
-          errors.push({ pdfId, collectionId, error: String(error) });
-          this.#logger.error(`Failed to ${action} ${pdfId} to ${collectionId}: ${error}`);
         }
       }
+
+      const verb = action === 'move' ? 'moved' : 'copied';
+      if (errors.length === 0) {
+        notify(`${successCount} document(s) ${verb} to "${collectionNames}"`, 'success', 'check-circle');
+      } else if (successCount > 0) {
+        notify(`${successCount} succeeded, ${errors.length} failed`, 'warning', 'exclamation-triangle');
+      } else {
+        notify(`Failed to ${action} all documents`, 'danger', 'exclamation-octagon');
+      }
+
+      this.#selectedDocuments.clear();
+      await this.getDependency('filedata').reload({ refresh: true });
+    } finally {
+      moveCopyButton.loading = false;
+      this.#updateMoveCopyButtonState();
     }
-
-    moveCopyButton.loading = false;
-
-    const verb = action === 'move' ? 'moved' : 'copied';
-    if (errors.length === 0) {
-      notify(`${successCount} document(s) ${verb} to "${collectionNames}"`, 'success', 'check-circle');
-    } else if (successCount > 0) {
-      notify(`${successCount} succeeded, ${errors.length} failed`, 'warning', 'exclamation-triangle');
-    } else {
-      notify(`Failed to ${action} all documents`, 'danger', 'exclamation-octagon');
-    }
-
-    this.#selectedDocuments.clear();
-    await this.getDependency('filedata').reload({ refresh: true });
   }
 
   /**

--- a/app/src/plugins/file-selection-drawer.js
+++ b/app/src/plugins/file-selection-drawer.js
@@ -44,7 +44,7 @@ class FileSelectionDrawerPlugin extends Plugin {
   constructor(context) {
     super(context, {
       name: 'file-selection-drawer',
-      deps: ['logger', 'dialog', 'client', 'filedata']
+      deps: ['logger', 'dialog', 'client', 'filedata', 'move-files']
     });
   }
 
@@ -62,6 +62,7 @@ class FileSelectionDrawerPlugin extends Plugin {
   get #logger() { return this.getDependency('logger') }
   get #dialog() { return this.getDependency('dialog') }
   get #client() { return this.getDependency('client') }
+  get #moveFiles() { return this.getDependency('move-files') }
 
   /** @type {HTMLElement & fileDrawerButtonPart} */
   #triggerUi = /** @type {any} */ (null)
@@ -76,6 +77,8 @@ class FileSelectionDrawerPlugin extends Plugin {
   #isUpdatingSelect = false;  // blocks sl-change on variantSelect during programmatic value sets
   /** @type {Set<string>} */
   #selectedCollections = new Set();
+  /** @type {Set<string>} PDF stable_ids checked for batch move/copy */
+  #selectedDocuments = new Set();
   /** @type {ExportFormatInfo[]} */
   #availableExportFormats = [];
 
@@ -165,6 +168,12 @@ class FileSelectionDrawerPlugin extends Plugin {
         await this.#handleNewCollection(this.state);
       } else {
         this.#logger.warn("New collection button clicked but no current state available");
+      }
+    });
+
+    this.#drawerUi.moveCopyButton.addEventListener('click', async () => {
+      if (this.state) {
+        await this.#handleMoveCopy(this.state);
       }
     });
 
@@ -330,14 +339,17 @@ class FileSelectionDrawerPlugin extends Plugin {
     const deleteButton = this.#drawerUi.deleteButton;
     const newCollectionButton = this.#drawerUi.newCollectionButton;
 
+    const moveCopyButton = this.#drawerUi.moveCopyButton;
     if (hasReviewerRole) {
       importButton.style.display = '';
       exportDropdown.style.display = '';
       newCollectionButton.style.display = '';
+      moveCopyButton.style.display = '';
     } else {
       importButton.style.display = 'none';
       exportDropdown.style.display = 'none';
       newCollectionButton.style.display = 'none';
+      moveCopyButton.style.display = 'none';
     }
     const isAdmin = user && user.roles && (user.roles.includes('*') || user.roles.includes('admin'));
     deleteButton.style.display = isAdmin || ownsAnyCollection ? '' : 'none';
@@ -447,7 +459,23 @@ class FileSelectionDrawerPlugin extends Plugin {
       pdfItem.dataset.collection = file.collections[0];
       const displayLabel = file.source?.label || file.doc_metadata?.title || file.doc_id;
       const icon = file.source?.file_type === 'pdf' ? 'file-pdf' : 'file-earmark-code';
-      pdfItem.innerHTML = `<sl-icon name="${icon}"></sl-icon><span>${displayLabel}</span>`;
+      const pdfId = file.source?.id || '';
+
+      const docCheckbox = /** @type {SlCheckbox} */ (document.createElement('sl-checkbox'));
+      docCheckbox.size = 'small';
+      docCheckbox.checked = this.#selectedDocuments.has(pdfId);
+      docCheckbox.addEventListener('click', e => e.stopPropagation());
+      docCheckbox.addEventListener('sl-change', e => {
+        e.stopPropagation();
+        this.#onDocumentCheckboxChange(pdfId, docCheckbox.checked, collectionName);
+      });
+      const iconEl = document.createElement('sl-icon');
+      iconEl.name = icon;
+      const labelEl = document.createElement('span');
+      labelEl.textContent = displayLabel;
+      pdfItem.appendChild(docCheckbox);
+      pdfItem.appendChild(iconEl);
+      pdfItem.appendChild(labelEl);
 
       if (goldToShow.length > 0) {
         const goldSection = document.createElement('sl-tree-item');
@@ -499,6 +527,8 @@ class FileSelectionDrawerPlugin extends Plugin {
    */
   async #populateFileTree(state) {
     if (!state.fileData) return;
+    this.#selectedDocuments.clear();
+    this.#updateMoveCopyButtonState();
 
     const fileTree = this.#drawerUi?.fileTree;
     if (!fileTree) return;
@@ -743,7 +773,69 @@ class FileSelectionDrawerPlugin extends Plugin {
     } else {
       this.#selectedCollections.delete(collectionName);
     }
+
+    // Sync document checkboxes — programmatic, does NOT fire sl-change
+    const collectionTreeItem = /** @type {HTMLElement|null} */ (
+      this.#drawerUi.fileTree.querySelector(`.collection-item[data-collection="${collectionName}"]`)
+    );
+    if (collectionTreeItem) {
+      const pdfItems = collectionTreeItem.querySelectorAll('.pdf-item');
+      pdfItems.forEach(item => {
+        const pdfCheckbox = /** @type {SlCheckbox} */ (item.querySelector('sl-checkbox'));
+        const pdfId = /** @type {HTMLElement} */ (item).dataset.hash;
+        if (pdfCheckbox && pdfId) {
+          pdfCheckbox.checked = checked;
+          if (checked) {
+            this.#selectedDocuments.add(pdfId);
+          } else {
+            this.#selectedDocuments.delete(pdfId);
+          }
+        }
+      });
+    }
+
     this.#updateExportButtonState();
+    this.#updateMoveCopyButtonState();
+  }
+
+  /**
+   * @param {string} pdfId
+   * @param {boolean} checked
+   * @param {string} collectionName
+   */
+  #onDocumentCheckboxChange(pdfId, checked, collectionName) {
+    if (checked) {
+      this.#selectedDocuments.add(pdfId);
+    } else {
+      this.#selectedDocuments.delete(pdfId);
+    }
+
+    // Update collection checkbox state (checked / indeterminate / unchecked)
+    const collectionTreeItem = /** @type {HTMLElement|null} */ (
+      this.#drawerUi.fileTree.querySelector(`.collection-item[data-collection="${collectionName}"]`)
+    );
+    if (collectionTreeItem) {
+      const pdfCheckboxes = /** @type {SlCheckbox[]} */ (
+        [...collectionTreeItem.querySelectorAll('.pdf-item sl-checkbox')]
+      );
+      const checkedCount = pdfCheckboxes.filter(cb => cb.checked).length;
+      const collectionCheckbox = /** @type {SlCheckbox} */ (
+        collectionTreeItem.querySelector('sl-checkbox')
+      );
+      if (collectionCheckbox) {
+        if (checkedCount === 0) {
+          collectionCheckbox.indeterminate = false;
+          collectionCheckbox.checked = false;
+        } else if (checkedCount === pdfCheckboxes.length) {
+          collectionCheckbox.indeterminate = false;
+          collectionCheckbox.checked = true;
+        } else {
+          collectionCheckbox.indeterminate = true;
+        }
+      }
+    }
+
+    this.#updateMoveCopyButtonState();
   }
 
   #onSelectAllChange() {
@@ -821,6 +913,11 @@ class FileSelectionDrawerPlugin extends Plugin {
     } else {
       checkbox.indeterminate = true;
     }
+  }
+
+  #updateMoveCopyButtonState() {
+    const moveCopyButton = this.#drawerUi.moveCopyButton;
+    moveCopyButton.disabled = this.#selectedDocuments.size === 0;
   }
 
   #updateExportButtonState() {
@@ -1075,6 +1172,76 @@ class FileSelectionDrawerPlugin extends Plugin {
       newCollectionButton.disabled = false;
       newCollectionButton.loading = false;
     }
+  }
+
+  /**
+   * @param {ApplicationState} state
+   */
+  async #handleMoveCopy(state) {
+    const pdfIds = Array.from(this.#selectedDocuments);
+    if (pdfIds.length === 0) return;
+
+    const result = await this.#moveFiles.showBatchDialog({
+      pdfIds,
+      collections: state.collections || [],
+      projects: state.projects || []
+    });
+
+    if (!result) return;
+
+    const { action, targetCollections } = result;
+
+    if (targetCollections.length === 0) {
+      this.#dialog.error('No collection selected.');
+      return;
+    }
+
+    const collectionNames = targetCollections
+      .map(id => (state.collections || []).find(c => c.id === id)?.name || id)
+      .join(', ');
+
+    const confirmMsg = action === 'move'
+      ? `Move ${pdfIds.length} document(s) to "${collectionNames}"?\n\nThis will remove them from their current collection(s).`
+      : `Copy ${pdfIds.length} document(s) to "${collectionNames}"?`;
+
+    if (!confirm(confirmMsg)) return;
+
+    const moveCopyButton = this.#drawerUi.moveCopyButton;
+    moveCopyButton.loading = true;
+    moveCopyButton.disabled = true;
+
+    let successCount = 0;
+    const errors = [];
+
+    for (const pdfId of pdfIds) {
+      for (const collectionId of targetCollections) {
+        try {
+          if (action === 'move') {
+            await this.#client.moveFiles(pdfId, collectionId);
+          } else {
+            await this.#client.copyFiles(pdfId, collectionId);
+          }
+          successCount++;
+        } catch (error) {
+          errors.push({ pdfId, collectionId, error: String(error) });
+          this.#logger.error(`Failed to ${action} ${pdfId} to ${collectionId}: ${error}`);
+        }
+      }
+    }
+
+    moveCopyButton.loading = false;
+
+    const verb = action === 'move' ? 'moved' : 'copied';
+    if (errors.length === 0) {
+      notify(`${successCount} document(s) ${verb} to "${collectionNames}"`, 'success', 'check-circle');
+    } else if (successCount > 0) {
+      notify(`${successCount} succeeded, ${errors.length} failed`, 'warning', 'exclamation-triangle');
+    } else {
+      notify(`Failed to ${action} all documents`, 'danger', 'exclamation-octagon');
+    }
+
+    this.#selectedDocuments.clear();
+    await this.getDependency('filedata').reload({ refresh: true });
   }
 
   /**

--- a/app/src/plugins/move-files.js
+++ b/app/src/plugins/move-files.js
@@ -151,15 +151,14 @@ class MoveFilesPlugin extends Plugin {
 
     ui.spinner.show(`${operationName} files, please wait...`)
     try {
-      let result
       if (isCopyMode) {
-        result = await this.#client.copyFiles(pdf, xml, destinationCollection)
+        await this.#client.copyFiles(pdf, destinationCollection)
       } else {
-        result = await this.#client.moveFiles(pdf, xml, destinationCollection)
+        await this.#client.moveFiles(pdf, destinationCollection)
       }
 
       await this.#fileSelection.reload()
-      await this.#services.load({ pdf: result.new_pdf_id, xml: result.new_xml_id })
+      await this.#services.load({ pdf })
 
       const destCollection = collections.find(c => c.id === destinationCollection)
       const collectionName = destCollection ? destCollection.name : destinationCollection

--- a/app/src/plugins/move-files.js
+++ b/app/src/plugins/move-files.js
@@ -1,50 +1,35 @@
 /**
- * This plugin allows moving files to a different collection.
+ * Service plugin for moving/copying files between collections.
+ * Exposes showBatchDialog() for use by FileSelectionDrawerPlugin.
  */
 
 /**
  * @import { PluginContext } from '../modules/plugin-context.js'
  * @import { ApplicationState } from '../state.js'
- * @import { SlButton } from '../ui.js'
+ * @import { CollectionInfo, ProjectInfo } from '../state.js'
  * @import { moveFilesDialogPart } from '../templates/move-files-dialog.types.js'
  */
 
 import { Plugin } from '../modules/plugin-base.js'
 import { notify } from '../modules/sl-utils.js'
 import { registerTemplate, createSingleFromTemplate } from '../ui.js'
-import ui from '../ui.js'
-import { userHasRole } from '../modules/acl-utils.js'
 
-// Register template
 await registerTemplate('move-files-dialog', 'move-files-dialog.html')
 
 class MoveFilesPlugin extends Plugin {
   /** @param {PluginContext} context */
   constructor(context) {
-    super(context, { name: 'move-files', deps: ['services', 'file-selection', 'logger', 'dialog', 'document-actions'] })
+    super(context, { name: 'move-files', deps: ['logger', 'dialog', 'client'] })
   }
 
-  get #client()          { return this.getDependency('client') }
-  get #services()        { return this.getDependency('services') }
-  get #logger()          { return this.getDependency('logger') }
-  get #dialog()          { return this.getDependency('dialog') }
-  get #fileSelection()   { return this.getDependency('file-selection') }
-  get #documentActions() { return this.getDependency('document-actions') }
-
-  /** @type {SlButton} */
-  #moveBtn = Object.assign(document.createElement('sl-button'), {
-    innerHTML: `<sl-icon name="folder-symlink"></sl-icon>`,
-    variant: 'default',
-    size: 'small',
-    name: 'moveFiles'
-  })
+  get #client() { return this.getDependency('client') }
+  get #logger() { return this.getDependency('logger') }
+  get #dialog() { return this.getDependency('dialog') }
 
   /** @type {import('../ui.js').SlDialog & moveFilesDialogPart} */
   #dialogUi = null
 
-  /**
-   * @param {ApplicationState} _state
-   */
+  /** @param {ApplicationState} _state */
   async install(_state) {
     await super.install(_state)
     this.#logger.debug(`Installing plugin "move-files"`)
@@ -52,125 +37,136 @@ class MoveFilesPlugin extends Plugin {
     const dialog = createSingleFromTemplate('move-files-dialog', document.body)
     this.#dialogUi = this.createUi(dialog)
 
-    this.#documentActions.addButton(this.#moveBtn)
-    this.#moveBtn.addEventListener('click', () => this.#showMoveFilesDialog())
-
     this.#dialogUi.newCollectionBtn.addEventListener('click', async () => {
       const newCollectionId = prompt("Enter new collection ID (Only letters, numbers, '-' and '_'):")
-      if (newCollectionId) {
-        if (!/^[a-zA-Z0-9_-]+$/.test(newCollectionId)) {
-          this.#dialog.error("Invalid collection ID. Only letters, numbers, hyphens, and underscores are allowed.")
-          return
-        }
-        const newCollectionName = prompt("Enter collection display name (optional, leave blank to use ID):")
-        try {
-          const result = await this.#client.createCollection(newCollectionId, newCollectionName || newCollectionId)
-          if (result.success) {
-            const placeholderOption = this.#dialogUi.collectionName.querySelector('sl-option[disabled]')
-            if (placeholderOption) placeholderOption.remove()
-            const option = Object.assign(document.createElement('sl-option'), {
-              value: newCollectionId,
-              textContent: newCollectionName || newCollectionId
-            })
-            this.#dialogUi.collectionName.append(option)
-            this.#dialogUi.collectionName.value = newCollectionId
-            notify(result.message)
-            await this.#fileSelection.reload()
-          }
-        } catch (error) {
-          this.#dialog.error(`Error creating collection: ${String(error)}`)
-        }
+      if (!newCollectionId) return
+      if (!/^[a-zA-Z0-9_-]+$/.test(newCollectionId)) {
+        this.#dialog.error("Invalid collection ID. Only letters, numbers, hyphens, and underscores are allowed.")
+        return
       }
-    })
-
-    this.#dialogUi.copyMode.addEventListener('sl-change', () => {
-      const isCopyMode = this.#dialogUi.copyMode.checked
-      this.#dialogUi.submit.submitLabel.textContent = isCopyMode ? 'Copy' : 'Move'
+      const newCollectionName = prompt("Enter collection display name (optional, leave blank to use ID):")
+      if (newCollectionName === null) return
+      try {
+        await this.#client.createCollection(newCollectionId, newCollectionName || newCollectionId)
+        this.#appendCollectionCheckbox(newCollectionId, newCollectionName || newCollectionId, true)
+        notify(`Collection '${newCollectionName || newCollectionId}' created`, 'success', 'check-circle')
+      } catch (error) {
+        this.#dialog.error(`Error creating collection: ${String(error)}`)
+      }
     })
   }
 
-  async onStateUpdate(_changedKeys) {
-    const isReviewer = userHasRole(this.state.user, ["admin", "reviewer"])
-    this.#moveBtn.disabled = !this.state.xml || !isReviewer
+  /**
+   * @param {string} id
+   * @param {string} name
+   * @param {boolean} [checked]
+   */
+  #appendCollectionCheckbox(id, name, checked = false) {
+    const div = document.createElement('div')
+    div.style.cssText = 'display: flex; align-items: center; padding: 0.25rem 0;'
+    const checkbox = /** @type {import('../ui.js').SlCheckbox} */ (document.createElement('sl-checkbox'))
+    checkbox.size = 'small'
+    checkbox.textContent = name
+    checkbox.checked = checked
+    checkbox.dataset.collectionId = id
+    checkbox.addEventListener('sl-change', () => this.#updateButtonStates())
+    div.appendChild(checkbox)
+    this.#dialogUi.collectionsList.appendChild(div)
+    this.#updateButtonStates()
   }
 
-  async #showMoveFilesDialog() {
-    const state = this.state
-    const { xml, pdf, collections } = state
-    if (!xml || !pdf) {
-      this.#dialog.error("Cannot move/copy files, PDF or XML path is missing.")
-      return
-    }
+  #updateButtonStates() {
+    const checkboxes = /** @type {import('../ui.js').SlCheckbox[]} */ ([
+      ...this.#dialogUi.collectionsList.querySelectorAll('sl-checkbox')
+    ])
+    const checkedCount = checkboxes.filter(cb => cb.checked).length
+    this.#dialogUi.moveBtn.disabled = checkedCount !== 1
+    this.#dialogUi.copyBtn.disabled = checkedCount === 0
+  }
 
-    this.#dialogUi.copyMode.checked = false
-    this.#dialogUi.submit.submitLabel.textContent = 'Move'
+  /**
+   * Opens a dialog to select target collection(s) for batch move/copy.
+   * @param {{
+   *   pdfIds: string[],
+   *   collections: CollectionInfo[],
+   *   projects: ProjectInfo[]
+   * }} params
+   * @returns {Promise<{action: 'move'|'copy', targetCollections: string[]}|null>}
+   */
+  async showBatchDialog({ pdfIds, collections, projects }) {
+    const dlg = this.#dialogUi
+    dlg.docCount.textContent = String(pdfIds.length)
+    dlg.collectionsList.innerHTML = ''
 
-    const collectionSelectBox = this.#dialogUi.collectionName
-    collectionSelectBox.innerHTML = ""
-
-    if (!collections || collections.length === 0) {
-      const placeholderOption = Object.assign(document.createElement('sl-option'), {
-        value: '',
-        textContent: '(No collections available - click "New" to create one)',
-        disabled: true
-      })
-      collectionSelectBox.append(placeholderOption)
-      collectionSelectBox.value = ''
-    } else {
-      for (const collection of collections) {
-        const option = Object.assign(document.createElement('sl-option'), {
-          value: collection.id,
-          textContent: collection.name
-        })
-        collectionSelectBox.append(option)
+    /** @param {CollectionInfo[]} cols */
+    const appendGroup = (cols) => {
+      for (const col of cols) {
+        this.#appendCollectionCheckbox(col.id, col.name)
       }
     }
 
-    try {
-      this.#dialogUi.show()
-      await new Promise((resolve, reject) => {
-        this.#dialogUi.submit.addEventListener('click', resolve, { once: true })
-        this.#dialogUi.cancel.addEventListener('click', reject, { once: true })
-        this.#dialogUi.addEventListener('sl-hide', e => e.preventDefault(), { once: true })
-      })
-    } catch (e) {
-      this.#logger.info("User cancelled move/copy files dialog")
-      return
-    } finally {
-      this.#dialogUi.hide()
+    const renderedIds = new Set()
+    for (const project of (projects || [])) {
+      const projectCols = /** @type {CollectionInfo[]} */ (
+        (project.collections || []).map(id => collections.find(c => c.id === id)).filter(Boolean)
+      )
+      if (projectCols.length === 0) continue
+      const heading = document.createElement('div')
+      heading.style.cssText = 'font-weight: bold; padding: 0.5rem 0 0.15rem; font-size: 0.85em; text-transform: uppercase; color: var(--sl-color-neutral-500);'
+      heading.textContent = project.name
+      dlg.collectionsList.appendChild(heading)
+      appendGroup(projectCols)
+      projectCols.forEach(c => renderedIds.add(c.id))
     }
 
-    const destinationCollection = String(collectionSelectBox.value)
-    if (!destinationCollection) {
-      this.#dialog.error("No collection selected. Please select a collection or create a new one.")
-      return
-    }
-
-    const isCopyMode = this.#dialogUi.copyMode.checked
-    const operationName = isCopyMode ? 'Copying' : 'Moving'
-
-    ui.spinner.show(`${operationName} files, please wait...`)
-    try {
-      if (isCopyMode) {
-        await this.#client.copyFiles(pdf, destinationCollection)
-      } else {
-        await this.#client.moveFiles(pdf, destinationCollection)
+    const orphans = collections.filter(c => !renderedIds.has(c.id))
+    if (orphans.length > 0) {
+      if (renderedIds.size > 0) {
+        const heading = document.createElement('div')
+        heading.style.cssText = 'font-weight: bold; padding: 0.5rem 0 0.15rem; font-size: 0.85em; text-transform: uppercase; color: var(--sl-color-neutral-500);'
+        heading.textContent = 'No project'
+        dlg.collectionsList.appendChild(heading)
       }
-
-      await this.#fileSelection.reload()
-      await this.#services.load({ pdf })
-
-      const destCollection = collections.find(c => c.id === destinationCollection)
-      const collectionName = destCollection ? destCollection.name : destinationCollection
-      notify(`Files ${isCopyMode ? 'copied' : 'moved'} to "${collectionName}"`)
-    } catch (error) {
-      this.#dialog.error(`Error ${isCopyMode ? 'copying' : 'moving'} files: ${String(error)}`)
-    } finally {
-      ui.spinner.hide()
+      appendGroup(orphans)
     }
+
+    if (collections.length === 0) {
+      const msg = document.createElement('p')
+      msg.style.color = 'var(--sl-color-neutral-500)'
+      msg.textContent = 'No collections available. Click "New" to create one.'
+      dlg.collectionsList.appendChild(msg)
+    }
+
+    this.#updateButtonStates()
+
+    /** @type {'move'|'copy'|null} */
+    let action = null
+    try {
+      dlg.show()
+      action = await new Promise((resolve, reject) => {
+        dlg.moveBtn.addEventListener('click', () => resolve('move'), { once: true })
+        dlg.copyBtn.addEventListener('click', () => resolve('copy'), { once: true })
+        dlg.cancel.addEventListener('click', reject, { once: true })
+        dlg.addEventListener('sl-hide', e => e.preventDefault(), { once: true })
+      })
+    } catch {
+      this.#logger.info("User cancelled batch move/copy dialog")
+      return null
+    } finally {
+      dlg.hide()
+    }
+
+    const checkboxes = /** @type {import('../ui.js').SlCheckbox[]} */ ([
+      ...dlg.collectionsList.querySelectorAll('sl-checkbox')
+    ])
+    const targetCollections = checkboxes
+      .filter(cb => cb.checked)
+      .map(cb => cb.dataset.collectionId)
+      .filter(/** @param {any} id */ id => Boolean(id))
+
+    return { action, targetCollections }
   }
 }
 
 export default MoveFilesPlugin
-
 export const plugin = MoveFilesPlugin

--- a/app/src/plugins/move-files.js
+++ b/app/src/plugins/move-files.js
@@ -8,6 +8,7 @@
  * @import { ApplicationState } from '../state.js'
  * @import { CollectionInfo, ProjectInfo } from '../state.js'
  * @import { moveFilesDialogPart } from '../templates/move-files-dialog.types.js'
+ * @import { SlDialog, SlCheckbox } from '../ui.js'
  */
 
 import { Plugin } from '../modules/plugin-base.js'
@@ -26,7 +27,7 @@ class MoveFilesPlugin extends Plugin {
   get #logger() { return this.getDependency('logger') }
   get #dialog() { return this.getDependency('dialog') }
 
-  /** @type {import('../ui.js').SlDialog & moveFilesDialogPart} */
+  /** @type {SlDialog & moveFilesDialogPart} */
   #dialogUi = null
 
   /** @param {ApplicationState} _state */
@@ -64,7 +65,7 @@ class MoveFilesPlugin extends Plugin {
   #appendCollectionCheckbox(id, name, checked = false) {
     const div = document.createElement('div')
     div.style.cssText = 'display: flex; align-items: center; padding: 0.25rem 0;'
-    const checkbox = /** @type {import('../ui.js').SlCheckbox} */ (document.createElement('sl-checkbox'))
+    const checkbox = /** @type {SlCheckbox} */ (document.createElement('sl-checkbox'))
     checkbox.size = 'small'
     checkbox.textContent = name
     checkbox.checked = checked
@@ -76,7 +77,7 @@ class MoveFilesPlugin extends Plugin {
   }
 
   #updateButtonStates() {
-    const checkboxes = /** @type {import('../ui.js').SlCheckbox[]} */ ([
+    const checkboxes = /** @type {SlCheckbox[]} */ ([
       ...this.#dialogUi.collectionsList.querySelectorAll('sl-checkbox')
     ])
     const checkedCount = checkboxes.filter(cb => cb.checked).length
@@ -105,6 +106,7 @@ class MoveFilesPlugin extends Plugin {
       }
     }
 
+    const headingStyle = 'font-weight: bold; padding: 0.5rem 0 0.15rem; font-size: 0.85em; text-transform: uppercase; color: var(--sl-color-neutral-500);'
     const renderedIds = new Set()
     for (const project of (projects || [])) {
       const projectCols = /** @type {CollectionInfo[]} */ (
@@ -112,7 +114,7 @@ class MoveFilesPlugin extends Plugin {
       )
       if (projectCols.length === 0) continue
       const heading = document.createElement('div')
-      heading.style.cssText = 'font-weight: bold; padding: 0.5rem 0 0.15rem; font-size: 0.85em; text-transform: uppercase; color: var(--sl-color-neutral-500);'
+      heading.style.cssText = headingStyle
       heading.textContent = project.name
       dlg.collectionsList.appendChild(heading)
       appendGroup(projectCols)
@@ -123,7 +125,7 @@ class MoveFilesPlugin extends Plugin {
     if (orphans.length > 0) {
       if (renderedIds.size > 0) {
         const heading = document.createElement('div')
-        heading.style.cssText = 'font-weight: bold; padding: 0.5rem 0 0.15rem; font-size: 0.85em; text-transform: uppercase; color: var(--sl-color-neutral-500);'
+        heading.style.cssText = headingStyle
         heading.textContent = 'No project'
         dlg.collectionsList.appendChild(heading)
       }
@@ -139,6 +141,9 @@ class MoveFilesPlugin extends Plugin {
 
     this.#updateButtonStates()
 
+    const preventClose = (e) => e.preventDefault()
+    dlg.addEventListener('sl-request-close', preventClose)
+
     /** @type {'move'|'copy'|null} */
     let action = null
     try {
@@ -147,22 +152,22 @@ class MoveFilesPlugin extends Plugin {
         dlg.moveBtn.addEventListener('click', () => resolve('move'), { once: true })
         dlg.copyBtn.addEventListener('click', () => resolve('copy'), { once: true })
         dlg.cancel.addEventListener('click', reject, { once: true })
-        dlg.addEventListener('sl-hide', e => e.preventDefault(), { once: true })
       })
     } catch {
       this.#logger.info("User cancelled batch move/copy dialog")
       return null
     } finally {
+      dlg.removeEventListener('sl-request-close', preventClose)
       dlg.hide()
     }
 
-    const checkboxes = /** @type {import('../ui.js').SlCheckbox[]} */ ([
+    const checkboxes = /** @type {SlCheckbox[]} */ ([
       ...dlg.collectionsList.querySelectorAll('sl-checkbox')
     ])
     const targetCollections = checkboxes
       .filter(cb => cb.checked)
       .map(cb => cb.dataset.collectionId)
-      .filter(/** @param {any} id */ id => Boolean(id))
+      .filter(id => Boolean(id))
 
     return { action, targetCollections }
   }

--- a/app/src/plugins/start.js
+++ b/app/src/plugins/start.js
@@ -140,7 +140,9 @@ class StartPlugin extends Plugin {
         })
 
         // the xpath of the (to be) selected node in the xml editor, setting the state triggers the selection
-        const xpath = UrlHash.get("xpath") || ''
+        // Discard non-absolute values (e.g. bare numbers stored by a stale/buggy session)
+        const rawXpath = UrlHash.get("xpath") || ''
+        const xpath = rawXpath.startsWith('/') ? rawXpath : ''
 
         // update the UI
         await this.dispatchStateChange({ xpath })

--- a/app/src/plugins/xml-annotation.js
+++ b/app/src/plugins/xml-annotation.js
@@ -16,6 +16,7 @@ import { XMLEditor } from '../modules/xmleditor.js'
 import ui from '../ui.js'
 import { notify } from '../modules/sl-utils.js'
 import { createAnnotationField, annotationTheme, navigateEffect, createNavigationField } from '../modules/codemirror/xml-annotation-decorations.js'
+import { findCmScrollContainer, getFirstVisibleCharacter, scrollCharacterToTop } from '../modules/codemirror/codemirror-utils.js'
 import { syntaxTree } from '@codemirror/language'
 import { EditorView } from '@codemirror/view'
 
@@ -114,6 +115,11 @@ class XmlAnnotationPlugin extends Plugin {
       this.scheduleStateChange({ view: null })
       return
     }
+    // Capture character position of first visible line before any layout changes.
+    const cmView = this.#xmlEditor.getView?.()
+    const scrollContainer = cmView ? findCmScrollContainer(cmView) : null
+    const savedPos = cmView && scrollContainer ? getFirstVisibleCharacter(cmView, scrollContainer) : 0
+
     this.#annotationMode = true
     if (this.#switch) this.#switch.checked = true
     this.#slot?.reconfigure([
@@ -133,10 +139,23 @@ class XmlAnnotationPlugin extends Plugin {
     headerToggle.checked = false
     ui.xmlEditor.headerbar.hidden = true
     ui.xmlEditor.toolbar.teiHeaderToggleWidget.disabled = true
-    this.#scrollToTextElement()
+    // Restore the first visible line after CM has re-rendered in the new mode.
+    // Two rAFs ensure CM's own layout update fires before we read lineBlockAt.
+    if (cmView && scrollContainer != null) {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          scrollCharacterToTop(cmView, scrollContainer, savedPos)
+        })
+      })
+    }
   }
 
   async #disableAnnotationMode() {
+    // Capture character position of first visible line before any layout changes.
+    const cmView = this.#xmlEditor.getView?.()
+    const scrollContainer = cmView ? findCmScrollContainer(cmView) : null
+    const savedPos = cmView && scrollContainer ? getFirstVisibleCharacter(cmView, scrollContainer) : 0
+
     this.#annotationMode = false
     if (this.#switch) this.#switch.checked = false
     this.#slot?.reconfigure([])
@@ -146,17 +165,29 @@ class XmlAnnotationPlugin extends Plugin {
     ui.xmlEditor.headerbar.hidden = false
     ui.xmlEditor.toolbar.lineWrappingSwitch.disabled = false
     ui.xmlEditor.toolbar.teiHeaderToggleWidget.disabled = false
-    // Restore TEI header to its pre-annotation visibility
+    // Restore TEI header to its pre-annotation state (explicit in both branches so toggle
+    // always reflects the previously user-selected state, not annotation-mode defaults).
+    const headerToggle = /** @type {any} */ (ui.xmlEditor.toolbar.teiHeaderToggleWidget)
     if (this.#wasHeaderVisible) {
       await this.#xmlEditor.unfoldByXpath?.('//tei:teiHeader')
-      const headerToggle = /** @type {any} */ (ui.xmlEditor.toolbar.teiHeaderToggleWidget)
       headerToggle.checked = true
+    } else {
+      headerToggle.checked = false
     }
     // Revert state if this was triggered internally (e.g. document removed, variant lost tagDefs).
     // Must not be awaited: called from onStateUpdate while propagation is active, so the deferred
     // Promise would deadlock (scheduleStateChange flushes only after propagation ends).
     if (this.state.view === 'annotation') {
       this.scheduleStateChange({ view: null })
+    }
+    // Restore the first visible line after CM has re-rendered in the new mode.
+    // Two rAFs ensure CM's own layout update fires before we read lineBlockAt.
+    if (cmView && scrollContainer != null) {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          scrollCharacterToTop(cmView, scrollContainer, savedPos)
+        })
+      })
     }
   }
 
@@ -179,7 +210,11 @@ class XmlAnnotationPlugin extends Plugin {
       this.#navField,
       EditorView.domEventHandlers({ mouseup: (e, view) => this.#onEditorMouseUp(e, view) })
     ])
-    this.#scrollToTextElement()
+    if (this.state?.xpath) {
+      this.#scrollToXpath(this.state.xpath)
+    } else {
+      this.#scrollToTextElement()
+    }
   }
 
   #scrollToTextElement() {
@@ -374,11 +409,20 @@ class XmlAnnotationPlugin extends Plugin {
    * Navigates the editor to the element matched by xpath: places the cursor right after the open
    * tag (= after the badge widget), scrolls it into view, and adds an `ann-navigated` border
    * decoration around the element content so the current element is visually distinct.
+   *
+   * Uses getDomNodesByXpath (ORDERED_NODE_ITERATOR_TYPE) rather than getSyntaxNodeByXpath
+   * (which internally uses FIRST_ORDERED_NODE_TYPE) to avoid a Firefox XPath evaluation error
+   * where type 9 throws "Result type mismatch" in certain timing contexts.
    * @param {string} xpath
    */
   #scrollToXpath(xpath) {
     try {
-      const syntaxNode = this.#xmlEditor.getSyntaxNodeByXpath?.(xpath)
+      const nodes = this.#xmlEditor.getDomNodesByXpath?.(xpath)
+      const domNode = nodes?.[0]
+      if (!domNode) return
+      const pos = this.#xmlEditor.getDomNodePosition?.(domNode)
+      if (pos == null) return
+      const syntaxNode = this.#xmlEditor.getSyntaxNodeAt?.(pos)
       if (!syntaxNode) return
       const openTag  = syntaxNode.firstChild
       const closeTag = syntaxNode.lastChild

--- a/app/src/plugins/xmleditor.js
+++ b/app/src/plugins/xmleditor.js
@@ -761,7 +761,11 @@ class XmlEditorPlugin extends Plugin {
     this.#setNavigationWidgetsVisible(hasNavigationPaths && Boolean(state.xml));
 
     // Update xpath selection and counter
-    if (state.xpath) {
+    if (state.xpath && !state.xpath.startsWith('/')) {
+      this.#logger.warn(`Discarding invalid xpath state: "${state.xpath}"`);
+      this.scheduleStateChange({ xpath: '' });
+    }
+    if (state.xpath?.startsWith('/')) {
       let { index, pathBeforePredicates, nonIndexPredicates } = parseXPath(state.xpath);
       const nonIndexedPath = pathBeforePredicates + nonIndexPredicates;
 
@@ -850,7 +854,7 @@ class XmlEditorPlugin extends Plugin {
     }
 
     // xpath state => selection
-    if (this.#xmlEditor.isReady() && state.xpath && state.xml) {
+    if (this.#xmlEditor.isReady() && state.xpath?.startsWith('/') && state.xml) {
       const { index, pathBeforePredicates } = parseXPath(state.xpath);
       try {
         const size = this.#xmlEditor.countDomNodesByXpath(pathBeforePredicates);

--- a/app/src/plugins/xmleditor.js
+++ b/app/src/plugins/xmleditor.js
@@ -8,12 +8,13 @@
  * @import { StatusButton } from '../modules/panels/widgets/status-button.js'
  * @import { StatusSwitch } from '../modules/panels/widgets/status-switch.js'
  * @import { StatusDropdown } from '../modules/panels/widgets/status-dropdown.js'
- * @import { UIPart, SlDropdown, SlMenu } from '../ui.js'
+ * @import { UIPart, SlDropdown, SlMenu, SlMenuItem } from '../ui.js'
  * @import { StatusBar } from '../modules/panels/status-bar.js'
  * @import { ToolBar } from '../modules/panels/tool-bar.js'
  * @import { xslViewerOverlayPart } from './xsl-viewer.js'
  * @import { UserData } from './authentication.js'
  * @import { PluginContext } from '../modules/plugin-context.js'
+ * @import { EditorTheme } from '../modules/codemirror/editor-themes.js'
  */
 
 import ui, { updateUi } from '../ui.js'
@@ -27,7 +28,8 @@ import { detectXmlIndentation } from '../modules/codemirror/codemirror-utils.js'
 import { getFileDataById } from '../modules/file-data-utils.js'
 import FiledataPlugin from './filedata.js'
 import { isGoldFile, userHasRole } from '../modules/acl-utils.js'
-import { registerTemplate, createFromTemplate } from '../modules/ui-system.js'
+import { registerTemplate, createFromTemplate, createSingleFromTemplate } from '../modules/ui-system.js'
+import { THEMES, getTheme } from '../modules/codemirror/editor-themes.js'
 import { notify } from '../modules/sl-utils.js'
 import * as tei_utils from '../modules/tei-utils.js'
 import { prettyPrintXmlDom } from '../modules/xml-utils.js'
@@ -51,6 +53,7 @@ await registerTemplate('xmleditor-tei-buttons', 'xmleditor-tei-buttons.html')
 await registerTemplate('xmleditor-import-export-buttons', 'xmleditor-import-export-buttons.html')
 await registerTemplate('xmleditor-statusbar', 'xmleditor-statusbar.html')
 await registerTemplate('xmleditor-statusbar-right', 'xmleditor-statusbar-right.html')
+await registerTemplate('xmleditor-theme-button', 'xmleditor-theme-button.html')
 
 //
 // UI
@@ -84,6 +87,8 @@ await registerTemplate('xmleditor-statusbar-right', 'xmleditor-statusbar-right.h
  * @property {StatusButton} uploadBtn - Upload document button
  * @property {StatusButton} downloadBtn - Download document button
  * @property {StatusButton} revisionHistoryBtn - Revision history button (added by tei-tools plugin)
+ * @property {SlDropdown} themeDropdown - Editor theme picker dropdown
+ * @property {SlMenu} themeMenu - Editor theme picker menu
  */
 
 /**
@@ -165,6 +170,10 @@ class XmlEditorPlugin extends Plugin {
   #uploadBtn;
   /** @type {StatusButton} */
   #downloadBtn;
+  /** @type {SlDropdown|null} */
+  #themeDropdown = null;
+  /** @type {SlMenu|null} */
+  #themeMenu = null;
 
   // Statusbar widget references
   /** @type {StatusSwitch} */
@@ -309,6 +318,50 @@ class XmlEditorPlugin extends Plugin {
         this.#toolbar.add(widget, importExportPriorities[index] || 1);
       }
     });
+
+    // Create theme selector button and add to toolbar (priority 1 - far right)
+    const themeButtonEl = createSingleFromTemplate('xmleditor-theme-button');
+    this.#toolbar.add(themeButtonEl, 1);
+
+    const themeDropdown = /** @type {SlDropdown} */ (themeButtonEl.querySelector('[name="themeDropdown"]'));
+    this.#themeDropdown = themeDropdown;
+    this.#themeMenu = /** @type {SlMenu} */ (themeButtonEl.querySelector('[name="themeMenu"]'));
+
+    // Build theme menu items from saved preference
+    const savedThemeId = this.uiStorage.get('editorTheme', 'default');
+    for (const theme of THEMES) {
+      const item = /** @type {SlMenuItem} */ (document.createElement('sl-menu-item'));
+      item.textContent = theme.label;
+      item.dataset.themeId = theme.id;
+      item.type = 'checkbox';
+      item.checked = theme.id === savedThemeId;
+      this.#themeMenu.appendChild(item);
+    }
+
+    // Apply saved theme to the editor
+    this.#xmlEditor.setTheme(getTheme(savedThemeId));
+
+    // Theme selection handler
+    this.#themeMenu.addEventListener('sl-select', (event) => {
+      const item = /** @type {SlMenuItem} */ (event.detail.item);
+      const themeId = item.dataset.themeId;
+      if (!themeId) return;
+      this.#xmlEditor.setTheme(getTheme(themeId));
+      this.uiStorage.set('editorTheme', themeId);
+      this.#themeMenu.querySelectorAll('sl-menu-item').forEach(el => {
+        /** @type {SlMenuItem} */ (el).checked = el.dataset.themeId === themeId;
+      });
+    });
+
+    // Fix z-index stacking context so the dropdown appears above the editor
+    if (themeDropdown) {
+      themeDropdown.addEventListener('sl-show', () => {
+        themeDropdown.closest('tool-bar')?.classList.add('dropdown-open');
+      });
+      themeDropdown.addEventListener('sl-hide', () => {
+        themeDropdown.closest('tool-bar')?.classList.remove('dropdown-open');
+      });
+    }
 
     // Read-only status widget (added dynamically when needed)
     this.#readOnlyStatusWidget = PanelUtils.createText({

--- a/app/src/templates/file-selection-drawer.html
+++ b/app/src/templates/file-selection-drawer.html
@@ -75,6 +75,11 @@
           <sl-icon name="plus"></sl-icon>
         </sl-button>
       </sl-tooltip>
+      <sl-tooltip content="Move or copy selected documents to a collection">
+        <sl-button name="moveCopyButton" variant="default" size="small" disabled style="display: none;">
+          <sl-icon name="folder-symlink"></sl-icon>
+        </sl-button>
+      </sl-tooltip>
     </div>
     <sl-button name="closeDrawer" variant="default" size="small">
       Close

--- a/app/src/templates/file-selection-drawer.types.js
+++ b/app/src/templates/file-selection-drawer.types.js
@@ -11,6 +11,7 @@
  * @property {import('../ui.js').SlDropdown & exportDropdownPart} exportDropdown
  * @property {import('../ui.js').SlButton} deleteButton
  * @property {import('../ui.js').SlButton} newCollectionButton
+ * @property {import('../ui.js').SlButton} moveCopyButton
  * @property {import('../ui.js').SlButton} closeDrawer
  * @property {HTMLInputElement} importFileInput
  */

--- a/app/src/templates/move-files-dialog.html
+++ b/app/src/templates/move-files-dialog.html
@@ -1,16 +1,12 @@
-<sl-dialog name="moveFilesDialog" label="Move/Copy Files to Collection">
-  <p>
-    Select a collection to move or copy the current PDF and XML files to.
-  </p>
-  <div style="display: flex; align-items: flex-end; gap: 0.5rem;">
-    <sl-select name="collectionName" label="Collection" required style="flex-grow: 1;" hoist></sl-select>
-    <sl-button name="newCollectionBtn" variant="default" outline>
-      <sl-icon name="plus-lg" slot="prefix"></sl-icon> New
-    </sl-button>
+<sl-dialog name="moveFilesDialog" label="Move/Copy to Collection">
+  <p>Select target collection(s) for the <span name="docCount">0</span> selected document(s).</p>
+  <div name="collectionsList" style="max-height: 300px; overflow-y: auto; padding: 0.25rem 0;">
+    <!-- Populated dynamically by MoveFilesPlugin.showBatchDialog() -->
   </div>
-  <sl-checkbox name="copyMode">Copy to collection (keep in current collection)</sl-checkbox>
-  <sl-button slot="footer" name="cancel">Cancel</sl-button>
-  <sl-button slot="footer" name="submit" variant="primary">
-    <span name="submitLabel">Move</span>
+  <sl-button slot="footer" name="newCollectionBtn" variant="default" outline>
+    <sl-icon name="plus-lg" slot="prefix"></sl-icon> New
   </sl-button>
+  <sl-button slot="footer" name="cancel">Cancel</sl-button>
+  <sl-button slot="footer" name="moveBtn" variant="primary" disabled>Move</sl-button>
+  <sl-button slot="footer" name="copyBtn" variant="default" disabled>Copy</sl-button>
 </sl-dialog>

--- a/app/src/templates/move-files-dialog.types.js
+++ b/app/src/templates/move-files-dialog.types.js
@@ -3,16 +3,12 @@
 
 /**
  * @typedef {object} moveFilesDialogPart
- * @property {import('../ui.js').SlSelect} collectionName
+ * @property {HTMLSpanElement} docCount
+ * @property {HTMLDivElement} collectionsList
  * @property {import('../ui.js').SlButton} newCollectionBtn
- * @property {import('../ui.js').SlCheckbox} copyMode
  * @property {import('../ui.js').SlButton} cancel
- * @property {import('../ui.js').SlButton & submitPart} submit
- */
-
-/**
- * @typedef {object} submitPart
- * @property {HTMLSpanElement} submitLabel
+ * @property {import('../ui.js').SlButton} moveBtn
+ * @property {import('../ui.js').SlButton} copyBtn
  */
 
 export {}

--- a/app/src/templates/xmleditor-theme-button.html
+++ b/app/src/templates/xmleditor-theme-button.html
@@ -1,0 +1,8 @@
+<sl-tooltip content="Editor theme">
+  <sl-dropdown name="themeDropdown" placement="bottom-end">
+    <sl-button name="themeBtn" variant="text" size="small" slot="trigger">
+      <sl-icon name="palette"></sl-icon>
+    </sl-button>
+    <sl-menu name="themeMenu"></sl-menu>
+  </sl-dropdown>
+</sl-tooltip>

--- a/app/web/importmap.json
+++ b/app/web/importmap.json
@@ -11,6 +11,7 @@
     "@codemirror/state": "../../node_modules/@codemirror/state/dist/index.js",
     "@codemirror/lint": "../../node_modules/@codemirror/lint/dist/index.js",
     "@codemirror/view": "../../node_modules/@codemirror/view/dist/index.js",
+    "@lezer/highlight": "../../node_modules/@lezer/highlight/dist/index.js",
     "markdown-it": "../../node_modules/markdown-it/index.mjs"
   },
   "scopes": {
@@ -40,7 +41,6 @@
       "@lezer/xml": "../../node_modules/@lezer/xml/dist/index.js"
     },
     "../../node_modules/@codemirror/language/": {
-      "@lezer/highlight": "../../node_modules/@lezer/highlight/dist/index.js",
       "@lezer/common": "../../node_modules/@lezer/common/dist/index.js",
       "style-mod": "../../node_modules/style-mod/src/style-mod.js"
     },
@@ -48,7 +48,6 @@
       "crelt": "../../node_modules/crelt/index.js"
     },
     "../../node_modules/@codemirror/merge/": {
-      "@lezer/highlight": "../../node_modules/@lezer/highlight/dist/index.js",
       "style-mod": "../../node_modules/style-mod/src/style-mod.js"
     },
     "../../node_modules/@codemirror/state/": {
@@ -84,7 +83,6 @@
       "mdurl": "../../node_modules/mdurl/index.mjs"
     },
     "../../node_modules/@lezer/xml/": {
-      "@lezer/highlight": "../../node_modules/@lezer/highlight/dist/index.js",
       "@lezer/lr": "../../node_modules/@lezer/lr/dist/index.js"
     },
     "../../node_modules/linkify-it/": {

--- a/docs/superpowers/plans/2026-06-21-batch-move-copy.md
+++ b/docs/superpowers/plans/2026-06-21-batch-move-copy.md
@@ -1,0 +1,942 @@
+# Batch Move/Copy (Issue #400) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add batch move/copy of selected documents from the Collection & Files Drawer, replacing the single-document toolbar button.
+
+**Architecture:** `MoveFilesPlugin` is refactored from a toolbar-button plugin into a service plugin with a public `showBatchDialog()` method. `FileSelectionDrawerPlugin` gains per-document checkboxes (PDF items in the tree), a move/copy button in the footer, and calls the service to perform batch operations.
+
+**Tech Stack:** Shoelace web components, vanilla JS, FastAPI backend (already updated — `xml_id` removed from move/copy endpoints in a prior commit).
+
+---
+
+## File Map
+
+| File | Change |
+| --- | --- |
+| `app/src/templates/move-files-dialog.html` | Redesign: collection checkboxes grouped by project instead of dropdown |
+| `app/src/templates/move-files-dialog.types.js` | Update typedef to match new HTML |
+| `app/src/plugins/move-files.js` | Remove toolbar button; add `showBatchDialog()` public method |
+| `app/src/templates/file-selection-drawer.html` | Add move/copy button in footer |
+| `app/src/templates/file-selection-drawer.types.js` | Add `moveCopyButton` to `fileDrawerPart` |
+| `app/src/plugins/file-selection-drawer.js` | Add document checkboxes, selection tracking, move/copy button wiring, batch execution |
+| `tests/e2e/tests/file-drawer-batch-move.spec.js` | New E2E test |
+
+**Dependency order:** Tasks 1–2 are independent. Task 3 (HTML/types) MUST be committed before Task 4 (JS) because the plugin code references `moveCopyButton` from the template.
+
+---
+
+## Task 1: Redesign move-files-dialog HTML and types
+
+**Files:**
+- Modify: `app/src/templates/move-files-dialog.html`
+- Modify: `app/src/templates/move-files-dialog.types.js`
+
+### Context
+
+The current dialog has a `sl-select` dropdown, a `copyMode` checkbox, and a single submit button. Replace everything with a scrollable `<div name="collectionsList">` (populated dynamically) plus separate Move and Copy buttons.
+
+- [ ] **Step 1: Replace move-files-dialog.html**
+
+Full replacement:
+
+```html
+<sl-dialog name="moveFilesDialog" label="Move/Copy to Collection">
+  <p>Select target collection(s) for the <span name="docCount">0</span> selected document(s).</p>
+  <div name="collectionsList" style="max-height: 300px; overflow-y: auto; padding: 0.25rem 0;">
+    <!-- Populated dynamically by MoveFilesPlugin.showBatchDialog() -->
+  </div>
+  <sl-button slot="footer" name="newCollectionBtn" variant="default" outline>
+    <sl-icon name="plus-lg" slot="prefix"></sl-icon> New
+  </sl-button>
+  <sl-button slot="footer" name="cancel">Cancel</sl-button>
+  <sl-button slot="footer" name="moveBtn" variant="primary" disabled>Move</sl-button>
+  <sl-button slot="footer" name="copyBtn" variant="default" disabled>Copy</sl-button>
+</sl-dialog>
+```
+
+- [ ] **Step 2: Update move-files-dialog.types.js**
+
+Full replacement:
+
+```js
+// AUTO-GENERATED from move-files-dialog.html — do not edit
+// Regenerate with: npm run build:ui-types
+
+/**
+ * @typedef {object} moveFilesDialogPart
+ * @property {HTMLSpanElement} docCount
+ * @property {HTMLDivElement} collectionsList
+ * @property {import('../ui.js').SlButton} newCollectionBtn
+ * @property {import('../ui.js').SlButton} cancel
+ * @property {import('../ui.js').SlButton} moveBtn
+ * @property {import('../ui.js').SlButton} copyBtn
+ */
+
+export {}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/templates/move-files-dialog.html app/src/templates/move-files-dialog.types.js
+git commit -m "feat(move-files): redesign dialog with collection checkboxes"
+```
+
+---
+
+## Task 2: Refactor MoveFilesPlugin as a service plugin
+
+**Files:**
+- Modify: `app/src/plugins/move-files.js`
+
+### Context
+
+Remove the toolbar button, `onStateUpdate`, and deps on `document-actions`/`file-selection`/`services`. Keep `client`, `logger`, `dialog`. Add public `showBatchDialog()` which populates the redesigned dialog and returns `{action, targetCollections}` or `null` on cancel.
+
+The `newCollectionBtn` handler creates the collection via API and immediately adds a checkbox for it to the open dialog — no file-data reload needed here (the drawer does that after the operation).
+
+- [ ] **Step 1: Replace move-files.js entirely**
+
+```js
+/**
+ * Service plugin for moving/copying files between collections.
+ * Exposes showBatchDialog() for use by FileSelectionDrawerPlugin.
+ */
+
+/**
+ * @import { PluginContext } from '../modules/plugin-context.js'
+ * @import { ApplicationState } from '../state.js'
+ * @import { CollectionInfo, ProjectInfo } from '../state.js'
+ * @import { moveFilesDialogPart } from '../templates/move-files-dialog.types.js'
+ */
+
+import { Plugin } from '../modules/plugin-base.js'
+import { notify } from '../modules/sl-utils.js'
+import { registerTemplate, createSingleFromTemplate } from '../ui.js'
+
+await registerTemplate('move-files-dialog', 'move-files-dialog.html')
+
+class MoveFilesPlugin extends Plugin {
+  /** @param {PluginContext} context */
+  constructor(context) {
+    super(context, { name: 'move-files', deps: ['logger', 'dialog', 'client'] })
+  }
+
+  get #client() { return this.getDependency('client') }
+  get #logger() { return this.getDependency('logger') }
+  get #dialog() { return this.getDependency('dialog') }
+
+  /** @type {import('../ui.js').SlDialog & moveFilesDialogPart} */
+  #dialogUi = null
+
+  /** @param {ApplicationState} _state */
+  async install(_state) {
+    await super.install(_state)
+    this.#logger.debug(`Installing plugin "move-files"`)
+
+    const dialog = createSingleFromTemplate('move-files-dialog', document.body)
+    this.#dialogUi = this.createUi(dialog)
+
+    this.#dialogUi.newCollectionBtn.addEventListener('click', async () => {
+      const newCollectionId = prompt("Enter new collection ID (Only letters, numbers, '-' and '_'):")
+      if (!newCollectionId) return
+      if (!/^[a-zA-Z0-9_-]+$/.test(newCollectionId)) {
+        this.#dialog.error("Invalid collection ID. Only letters, numbers, hyphens, and underscores are allowed.")
+        return
+      }
+      const newCollectionName = prompt("Enter collection display name (optional, leave blank to use ID):")
+      if (newCollectionName === null) return
+      try {
+        await this.#client.createCollection(newCollectionId, newCollectionName || newCollectionId)
+        this.#appendCollectionCheckbox(newCollectionId, newCollectionName || newCollectionId, true)
+        notify(`Collection '${newCollectionName || newCollectionId}' created`, 'success', 'check-circle')
+      } catch (error) {
+        this.#dialog.error(`Error creating collection: ${String(error)}`)
+      }
+    })
+  }
+
+  /**
+   * @param {string} id
+   * @param {string} name
+   * @param {boolean} [checked]
+   */
+  #appendCollectionCheckbox(id, name, checked = false) {
+    const div = document.createElement('div')
+    div.style.cssText = 'display: flex; align-items: center; padding: 0.25rem 0;'
+    const checkbox = /** @type {import('../ui.js').SlCheckbox} */ (document.createElement('sl-checkbox'))
+    checkbox.size = 'small'
+    checkbox.textContent = name
+    checkbox.checked = checked
+    checkbox.dataset.collectionId = id
+    checkbox.addEventListener('sl-change', () => this.#updateButtonStates())
+    div.appendChild(checkbox)
+    this.#dialogUi.collectionsList.appendChild(div)
+    this.#updateButtonStates()
+  }
+
+  #updateButtonStates() {
+    const checkboxes = /** @type {import('../ui.js').SlCheckbox[]} */ ([
+      ...this.#dialogUi.collectionsList.querySelectorAll('sl-checkbox')
+    ])
+    const checkedCount = checkboxes.filter(cb => cb.checked).length
+    this.#dialogUi.moveBtn.disabled = checkedCount !== 1
+    this.#dialogUi.copyBtn.disabled = checkedCount === 0
+  }
+
+  /**
+   * Opens a dialog to select target collection(s) for batch move/copy.
+   * @param {{
+   *   pdfIds: string[],
+   *   collections: CollectionInfo[],
+   *   projects: ProjectInfo[]
+   * }} params
+   * @returns {Promise<{action: 'move'|'copy', targetCollections: string[]}|null>}
+   */
+  async showBatchDialog({ pdfIds, collections, projects }) {
+    const dlg = this.#dialogUi
+    dlg.docCount.textContent = String(pdfIds.length)
+    dlg.collectionsList.innerHTML = ''
+
+    /** @param {CollectionInfo[]} cols */
+    const appendGroup = (cols) => {
+      for (const col of cols) {
+        this.#appendCollectionCheckbox(col.id, col.name)
+      }
+    }
+
+    const renderedIds = new Set()
+    for (const project of (projects || [])) {
+      const projectCols = /** @type {CollectionInfo[]} */ (
+        (project.collections || []).map(id => collections.find(c => c.id === id)).filter(Boolean)
+      )
+      if (projectCols.length === 0) continue
+      const heading = document.createElement('div')
+      heading.style.cssText = 'font-weight: bold; padding: 0.5rem 0 0.15rem; font-size: 0.85em; text-transform: uppercase; color: var(--sl-color-neutral-500);'
+      heading.textContent = project.name
+      dlg.collectionsList.appendChild(heading)
+      appendGroup(projectCols)
+      projectCols.forEach(c => renderedIds.add(c.id))
+    }
+
+    const orphans = collections.filter(c => !renderedIds.has(c.id))
+    if (orphans.length > 0) {
+      if (renderedIds.size > 0) {
+        const heading = document.createElement('div')
+        heading.style.cssText = 'font-weight: bold; padding: 0.5rem 0 0.15rem; font-size: 0.85em; text-transform: uppercase; color: var(--sl-color-neutral-500);'
+        heading.textContent = 'No project'
+        dlg.collectionsList.appendChild(heading)
+      }
+      appendGroup(orphans)
+    }
+
+    if (collections.length === 0) {
+      const msg = document.createElement('p')
+      msg.style.color = 'var(--sl-color-neutral-500)'
+      msg.textContent = 'No collections available. Click "New" to create one.'
+      dlg.collectionsList.appendChild(msg)
+    }
+
+    this.#updateButtonStates()
+
+    /** @type {'move'|'copy'|null} */
+    let action = null
+    try {
+      dlg.show()
+      action = await new Promise((resolve, reject) => {
+        dlg.moveBtn.addEventListener('click', () => resolve('move'), { once: true })
+        dlg.copyBtn.addEventListener('click', () => resolve('copy'), { once: true })
+        dlg.cancel.addEventListener('click', reject, { once: true })
+        dlg.addEventListener('sl-hide', e => e.preventDefault(), { once: true })
+      })
+    } catch {
+      this.#logger.info("User cancelled batch move/copy dialog")
+      return null
+    } finally {
+      dlg.hide()
+    }
+
+    const checkboxes = /** @type {import('../ui.js').SlCheckbox[]} */ ([
+      ...dlg.collectionsList.querySelectorAll('sl-checkbox')
+    ])
+    const targetCollections = checkboxes
+      .filter(cb => cb.checked)
+      .map(cb => cb.dataset.collectionId)
+      .filter(/** @param {any} id */ id => Boolean(id))
+
+    return { action, targetCollections }
+  }
+}
+
+export default MoveFilesPlugin
+export const plugin = MoveFilesPlugin
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/src/plugins/move-files.js
+git commit -m "feat(move-files): refactor as service plugin with showBatchDialog()"
+```
+
+---
+
+## Task 3: Add move/copy button to drawer HTML and update types
+
+**Files:**
+- Modify: `app/src/templates/file-selection-drawer.html`
+- Modify: `app/src/templates/file-selection-drawer.types.js`
+
+### Context
+
+The button must exist in the HTML **before** the JS plugin code that references it (Task 4). Adding it here in its own commit ensures the template is up to date.
+
+- [ ] **Step 1: Add move/copy button to `file-selection-drawer.html`**
+
+In the footer, find the `<sl-tooltip content="Create new collection">` block. Add the move/copy button AFTER its closing `</sl-tooltip>`:
+
+```html
+      <sl-tooltip content="Move or copy selected documents to a collection">
+        <sl-button name="moveCopyButton" variant="default" size="small" disabled style="display: none;">
+          <sl-icon name="folder-symlink"></sl-icon>
+        </sl-button>
+      </sl-tooltip>
+```
+
+The `style="display: none;"` hides it until `#updateButtonVisibility()` reveals it for reviewer/admin roles.
+
+- [ ] **Step 2: Update `file-selection-drawer.types.js`**
+
+In the `fileDrawerPart` typedef, add after `newCollectionButton`:
+
+```js
+ * @property {import('../ui.js').SlButton} moveCopyButton
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/templates/file-selection-drawer.html app/src/templates/file-selection-drawer.types.js
+git commit -m "feat(drawer): add move/copy button to footer template"
+```
+
+---
+
+## Task 4: Add document checkboxes, selection tracking, and batch handler to the drawer plugin
+
+**Files:**
+- Modify: `app/src/plugins/file-selection-drawer.js`
+
+### Context
+
+This task makes all JS changes to `file-selection-drawer.js`. The HTML from Task 3 must already be committed.
+
+**Key Shoelace facts:**
+- Setting `checkbox.checked = value` programmatically does NOT fire `sl-change`. Update `#selectedDocuments` manually in those cases.
+- `checkbox.indeterminate = true` makes the checkbox show as partially checked (Shoelace supports this property).
+- `sl-tree` with `selection="leaf"` fires `sl-selection-change` on item clicks. Checkbox clicks are stopped from propagating (`e.stopPropagation()`) so they don't accidentally select the tree item.
+- The FIRST `sl-checkbox` inside a `.collection-item` is the collection's own checkbox. `.pdf-item sl-checkbox` selects only the per-document checkboxes.
+
+- [ ] **Step 1: Add `'move-files'` to the deps array**
+
+In the constructor, change:
+```js
+    super(context, {
+      name: 'file-selection-drawer',
+      deps: ['logger', 'dialog', 'client', 'filedata']
+    });
+```
+to:
+```js
+    super(context, {
+      name: 'file-selection-drawer',
+      deps: ['logger', 'dialog', 'client', 'filedata', 'move-files']
+    });
+```
+
+- [ ] **Step 2: Add `#selectedDocuments` field**
+
+Add after `/** @type {ExportFormatInfo[]} */ #availableExportFormats = [];`:
+```js
+  /** @type {Set<string>} PDF stable_ids checked for batch move/copy */
+  #selectedDocuments = new Set();
+```
+
+- [ ] **Step 3: Add `#moveFiles` getter**
+
+Add after `get #client() { return this.getDependency('client') }`:
+```js
+  get #moveFiles() { return this.getDependency('move-files') }
+```
+
+- [ ] **Step 4: Add event listener for move/copy button in `install()`**
+
+After the `this.#drawerUi.newCollectionButton.addEventListener(...)` block in `install()`, add:
+```js
+    this.#drawerUi.moveCopyButton.addEventListener('click', async () => {
+      if (this.state) {
+        await this.#handleMoveCopy(this.state);
+      }
+    });
+```
+
+- [ ] **Step 5: Clear `#selectedDocuments` at the start of `#populateFileTree()`**
+
+At the very top of `#populateFileTree(state)` (before `if (!state.fileData) return`), add:
+```js
+    this.#selectedDocuments.clear();
+    this.#updateMoveCopyButtonState();
+```
+
+- [ ] **Step 6: Add document checkbox to each `pdfItem` in `#buildCollectionTreeItem()`**
+
+Find these three lines (they appear once inside `#buildCollectionTreeItem`):
+```js
+      const displayLabel = file.source?.label || file.doc_metadata?.title || file.doc_id
+      const icon = file.source?.file_type === 'pdf' ? 'file-pdf' : 'file-earmark-code'
+      pdfItem.innerHTML = `<sl-icon name="${icon}"></sl-icon><span>${displayLabel}</span>`
+```
+
+Replace with:
+```js
+      const displayLabel = file.source?.label || file.doc_metadata?.title || file.doc_id
+      const icon = file.source?.file_type === 'pdf' ? 'file-pdf' : 'file-earmark-code'
+      const pdfId = file.source?.id || ''
+
+      const docCheckbox = /** @type {import('../ui.js').SlCheckbox} */ (document.createElement('sl-checkbox'))
+      docCheckbox.size = 'small'
+      docCheckbox.checked = this.#selectedDocuments.has(pdfId)
+      docCheckbox.addEventListener('click', e => e.stopPropagation())
+      docCheckbox.addEventListener('sl-change', e => {
+        e.stopPropagation()
+        this.#onDocumentCheckboxChange(pdfId, docCheckbox.checked, collectionName)
+      })
+      const iconEl = document.createElement('sl-icon')
+      iconEl.name = icon
+      const labelEl = document.createElement('span')
+      labelEl.textContent = displayLabel
+      pdfItem.appendChild(docCheckbox)
+      pdfItem.appendChild(iconEl)
+      pdfItem.appendChild(labelEl)
+```
+
+- [ ] **Step 7: Update `#onCollectionCheckboxChange()` to sync document checkboxes**
+
+The current method body is:
+```js
+  #onCollectionCheckboxChange(collectionName, checked) {
+    if (checked) {
+      this.#selectedCollections.add(collectionName);
+    } else {
+      this.#selectedCollections.delete(collectionName);
+    }
+    this.#updateExportButtonState();
+  }
+```
+
+Replace with:
+```js
+  #onCollectionCheckboxChange(collectionName, checked) {
+    if (checked) {
+      this.#selectedCollections.add(collectionName);
+    } else {
+      this.#selectedCollections.delete(collectionName);
+    }
+
+    // Sync document checkboxes — programmatic, does NOT fire sl-change
+    const collectionTreeItem = /** @type {HTMLElement|null} */ (
+      this.#drawerUi.fileTree.querySelector(`.collection-item[data-collection="${collectionName}"]`)
+    );
+    if (collectionTreeItem) {
+      const pdfItems = collectionTreeItem.querySelectorAll('.pdf-item');
+      pdfItems.forEach(item => {
+        const pdfCheckbox = /** @type {import('../ui.js').SlCheckbox} */ (item.querySelector('sl-checkbox'));
+        const pdfId = /** @type {HTMLElement} */ (item).dataset.hash;
+        if (pdfCheckbox && pdfId) {
+          pdfCheckbox.checked = checked;
+          if (checked) {
+            this.#selectedDocuments.add(pdfId);
+          } else {
+            this.#selectedDocuments.delete(pdfId);
+          }
+        }
+      });
+    }
+
+    this.#updateExportButtonState();
+    this.#updateMoveCopyButtonState();
+  }
+```
+
+- [ ] **Step 8: Add `#onDocumentCheckboxChange()` method**
+
+Add this new method immediately after `#onCollectionCheckboxChange()`:
+```js
+  /**
+   * @param {string} pdfId
+   * @param {boolean} checked
+   * @param {string} collectionName
+   */
+  #onDocumentCheckboxChange(pdfId, checked, collectionName) {
+    if (checked) {
+      this.#selectedDocuments.add(pdfId);
+    } else {
+      this.#selectedDocuments.delete(pdfId);
+    }
+
+    // Update collection checkbox state (checked / indeterminate / unchecked)
+    const collectionTreeItem = /** @type {HTMLElement|null} */ (
+      this.#drawerUi.fileTree.querySelector(`.collection-item[data-collection="${collectionName}"]`)
+    );
+    if (collectionTreeItem) {
+      const pdfCheckboxes = /** @type {import('../ui.js').SlCheckbox[]} */ (
+        [...collectionTreeItem.querySelectorAll('.pdf-item sl-checkbox')]
+      );
+      const checkedCount = pdfCheckboxes.filter(cb => cb.checked).length;
+      const collectionCheckbox = /** @type {import('../ui.js').SlCheckbox} */ (
+        collectionTreeItem.querySelector('sl-checkbox')
+      );
+      if (collectionCheckbox) {
+        if (checkedCount === 0) {
+          collectionCheckbox.indeterminate = false;
+          collectionCheckbox.checked = false;
+        } else if (checkedCount === pdfCheckboxes.length) {
+          collectionCheckbox.indeterminate = false;
+          collectionCheckbox.checked = true;
+        } else {
+          collectionCheckbox.indeterminate = true;
+        }
+      }
+    }
+
+    this.#updateMoveCopyButtonState();
+  }
+```
+
+- [ ] **Step 9: Add `#updateMoveCopyButtonState()` method**
+
+Add after `#updateExportButtonState()`:
+```js
+  #updateMoveCopyButtonState() {
+    const moveCopyButton = this.#drawerUi.moveCopyButton;
+    moveCopyButton.disabled = this.#selectedDocuments.size === 0;
+  }
+```
+
+- [ ] **Step 10: Update `#updateButtonVisibility()` to show/hide the move/copy button**
+
+In `#updateButtonVisibility(state)`, find the `if (hasReviewerRole)` block:
+```js
+    if (hasReviewerRole) {
+      importButton.style.display = '';
+      exportDropdown.style.display = '';
+      newCollectionButton.style.display = '';
+    } else {
+      importButton.style.display = 'none';
+      exportDropdown.style.display = 'none';
+      newCollectionButton.style.display = 'none';
+    }
+```
+
+Replace with:
+```js
+    const moveCopyButton = this.#drawerUi.moveCopyButton;
+    if (hasReviewerRole) {
+      importButton.style.display = '';
+      exportDropdown.style.display = '';
+      newCollectionButton.style.display = '';
+      moveCopyButton.style.display = '';
+    } else {
+      importButton.style.display = 'none';
+      exportDropdown.style.display = 'none';
+      newCollectionButton.style.display = 'none';
+      moveCopyButton.style.display = 'none';
+    }
+```
+
+- [ ] **Step 11: Add `#handleMoveCopy()` method**
+
+Add before the `#handleDelete()` method:
+```js
+  /**
+   * @param {ApplicationState} state
+   */
+  async #handleMoveCopy(state) {
+    const pdfIds = Array.from(this.#selectedDocuments);
+    if (pdfIds.length === 0) return;
+
+    const result = await this.#moveFiles.showBatchDialog({
+      pdfIds,
+      collections: state.collections || [],
+      projects: state.projects || []
+    });
+
+    if (!result) return;
+
+    const { action, targetCollections } = result;
+
+    if (targetCollections.length === 0) {
+      this.#dialog.error('No collection selected.');
+      return;
+    }
+
+    const collectionNames = targetCollections
+      .map(id => (state.collections || []).find(c => c.id === id)?.name || id)
+      .join(', ');
+
+    const confirmMsg = action === 'move'
+      ? `Move ${pdfIds.length} document(s) to "${collectionNames}"?\n\nThis will remove them from their current collection(s).`
+      : `Copy ${pdfIds.length} document(s) to "${collectionNames}"?`;
+
+    if (!confirm(confirmMsg)) return;
+
+    const moveCopyButton = this.#drawerUi.moveCopyButton;
+    moveCopyButton.loading = true;
+    moveCopyButton.disabled = true;
+
+    let successCount = 0;
+    const errors = [];
+
+    for (const pdfId of pdfIds) {
+      for (const collectionId of targetCollections) {
+        try {
+          if (action === 'move') {
+            await this.#client.moveFiles(pdfId, collectionId);
+          } else {
+            await this.#client.copyFiles(pdfId, collectionId);
+          }
+          successCount++;
+        } catch (error) {
+          errors.push({ pdfId, collectionId, error: String(error) });
+          this.#logger.error(`Failed to ${action} ${pdfId} to ${collectionId}: ${error}`);
+        }
+      }
+    }
+
+    moveCopyButton.loading = false;
+
+    const verb = action === 'move' ? 'moved' : 'copied';
+    if (errors.length === 0) {
+      notify(`${successCount} document(s) ${verb} to "${collectionNames}"`, 'success', 'check-circle');
+    } else if (successCount > 0) {
+      notify(`${successCount} succeeded, ${errors.length} failed`, 'warning', 'exclamation-triangle');
+    } else {
+      notify(`Failed to ${action} all documents`, 'danger', 'exclamation-octagon');
+    }
+
+    this.#selectedDocuments.clear();
+    await this.getDependency('filedata').reload({ refresh: true });
+  }
+```
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add app/src/plugins/file-selection-drawer.js
+git commit -m "feat(drawer): add document checkboxes, selection tracking, and batch move/copy"
+```
+
+---
+
+## Task 5: E2E test
+
+**Files:**
+- Create: `tests/e2e/tests/file-drawer-batch-move.spec.js`
+
+### Context
+
+The test runs against a live dev server. Test users: `testreviewer`/`reviewerpass` and `testadmin`/`adminpass`. Collections and files are assumed to exist (populated by the test environment). `confirm()` dialogs must be intercepted with `page.once('dialog', async d => d.accept())` registered BEFORE the action that triggers them. Always wait 200–500ms after Shoelace interactions. Buttons with `disabled` attribute can't be clicked — assert the attribute before trying.
+
+- [ ] **Step 1: Create the test file**
+
+```js
+/**
+ * Batch move/copy E2E tests.
+ *
+ * @testCovers app/src/plugins/file-selection-drawer.js
+ * @testCovers app/src/plugins/move-files.js
+ * @testCovers fastapi_app/routers/files_move.py
+ */
+
+import { test, expect } from '../fixtures/debug-on-failure.js';
+import { setupTestConsoleCapture, setupErrorFailure } from './helpers/test-logging.js';
+import { navigateAndLogin, performLogout } from './helpers/login-helper.js';
+
+const ALLOWED_ERROR_PATTERNS = [
+  'Failed to load resource.*401.*UNAUTHORIZED',
+  'Failed to load resource.*400.*BAD REQUEST',
+  'offsetParent is not set.*cannot scroll'
+];
+
+test.describe('Batch Move/Copy from File Drawer', () => {
+
+  test('document checkboxes appear on PDF items and move/copy button is hidden by default', async ({ page }) => {
+    const consoleLogs = setupTestConsoleCapture(page);
+    const stopErrorMonitoring = setupErrorFailure(consoleLogs, ALLOWED_ERROR_PATTERNS);
+    try {
+      await navigateAndLogin(page, 'testreviewer', 'reviewerpass');
+      await page.waitForTimeout(1000);
+
+      await page.locator('sl-button[name="fileDrawerTrigger"]').click();
+      await page.waitForTimeout(500);
+      await expect(page.locator('sl-drawer[name="fileDrawer"]')).toHaveAttribute('open', '');
+
+      const pdfItems = page.locator('.pdf-item');
+      const count = await pdfItems.count();
+      if (count > 0) {
+        await expect(pdfItems.first().locator('sl-checkbox')).toBeVisible();
+        const moveCopyButton = page.locator('sl-button[name="moveCopyButton"]');
+        await expect(moveCopyButton).toBeVisible();
+        await expect(moveCopyButton).toHaveAttribute('disabled', '');
+      }
+
+      await page.locator('sl-button[name="closeDrawer"]').click();
+      await performLogout(page);
+    } finally {
+      stopErrorMonitoring();
+    }
+  });
+
+  test('checking a document enables the move/copy button; unchecking disables it', async ({ page }) => {
+    const consoleLogs = setupTestConsoleCapture(page);
+    const stopErrorMonitoring = setupErrorFailure(consoleLogs, ALLOWED_ERROR_PATTERNS);
+    try {
+      await navigateAndLogin(page, 'testreviewer', 'reviewerpass');
+      await page.waitForTimeout(1000);
+
+      await page.locator('sl-button[name="fileDrawerTrigger"]').click();
+      await page.waitForTimeout(500);
+
+      const pdfItems = page.locator('.pdf-item');
+      if (await pdfItems.count() === 0) {
+        await page.locator('sl-button[name="closeDrawer"]').click();
+        return;
+      }
+
+      const moveCopyButton = page.locator('sl-button[name="moveCopyButton"]');
+      await expect(moveCopyButton).toHaveAttribute('disabled', '');
+
+      await pdfItems.first().locator('sl-checkbox').click();
+      await page.waitForTimeout(300);
+      await expect(moveCopyButton).not.toHaveAttribute('disabled');
+
+      await pdfItems.first().locator('sl-checkbox').click();
+      await page.waitForTimeout(300);
+      await expect(moveCopyButton).toHaveAttribute('disabled', '');
+
+      await page.locator('sl-button[name="closeDrawer"]').click();
+      await performLogout(page);
+    } finally {
+      stopErrorMonitoring();
+    }
+  });
+
+  test('collection checkbox toggles all document checkboxes and updates move/copy button', async ({ page }) => {
+    const consoleLogs = setupTestConsoleCapture(page);
+    const stopErrorMonitoring = setupErrorFailure(consoleLogs, ALLOWED_ERROR_PATTERNS);
+    try {
+      await navigateAndLogin(page, 'testreviewer', 'reviewerpass');
+      await page.waitForTimeout(1000);
+
+      await page.locator('sl-button[name="fileDrawerTrigger"]').click();
+      await page.waitForTimeout(500);
+
+      const firstCollection = page.locator('.collection-item').first();
+      if (await firstCollection.count() === 0) {
+        await page.locator('sl-button[name="closeDrawer"]').click();
+        return;
+      }
+
+      const pdfCheckboxes = firstCollection.locator('.pdf-item sl-checkbox');
+      const pdfCount = await pdfCheckboxes.count();
+      if (pdfCount === 0) {
+        await page.locator('sl-button[name="closeDrawer"]').click();
+        return;
+      }
+
+      // Check the collection checkbox (first sl-checkbox directly inside the collection item)
+      const collectionCheckbox = firstCollection.locator('> sl-checkbox');
+      await collectionCheckbox.click();
+      await page.waitForTimeout(300);
+
+      for (let i = 0; i < pdfCount; i++) {
+        await expect(pdfCheckboxes.nth(i)).toHaveJSProperty('checked', true);
+      }
+      await expect(page.locator('sl-button[name="moveCopyButton"]')).not.toHaveAttribute('disabled');
+
+      // Uncheck collection
+      await collectionCheckbox.click();
+      await page.waitForTimeout(300);
+      for (let i = 0; i < pdfCount; i++) {
+        await expect(pdfCheckboxes.nth(i)).toHaveJSProperty('checked', false);
+      }
+      await expect(page.locator('sl-button[name="moveCopyButton"]')).toHaveAttribute('disabled', '');
+
+      await page.locator('sl-button[name="closeDrawer"]').click();
+      await performLogout(page);
+    } finally {
+      stopErrorMonitoring();
+    }
+  });
+
+  test('dialog enforces move-to-one constraint: Move disabled when >1 collections selected', async ({ page }) => {
+    const consoleLogs = setupTestConsoleCapture(page);
+    const stopErrorMonitoring = setupErrorFailure(consoleLogs, ALLOWED_ERROR_PATTERNS);
+    try {
+      await navigateAndLogin(page, 'testadmin', 'adminpass');
+      await page.waitForTimeout(1000);
+
+      await page.locator('sl-button[name="fileDrawerTrigger"]').click();
+      await page.waitForTimeout(500);
+
+      const pdfItems = page.locator('.pdf-item');
+      if (await pdfItems.count() === 0) {
+        await page.locator('sl-button[name="closeDrawer"]').click();
+        return;
+      }
+
+      await pdfItems.first().locator('sl-checkbox').click();
+      await page.waitForTimeout(300);
+      await page.locator('sl-button[name="moveCopyButton"]').click();
+      await page.waitForTimeout(500);
+
+      const dialog = page.locator('sl-dialog[name="moveFilesDialog"]');
+      await expect(dialog).toHaveAttribute('open', '');
+
+      const moveBtn = dialog.locator('sl-button[name="moveBtn"]');
+      const copyBtn = dialog.locator('sl-button[name="copyBtn"]');
+      await expect(moveBtn).toHaveAttribute('disabled', '');
+      await expect(copyBtn).toHaveAttribute('disabled', '');
+
+      const dialogCheckboxes = dialog.locator('[name="collectionsList"] sl-checkbox');
+      const colCount = await dialogCheckboxes.count();
+
+      if (colCount >= 2) {
+        await dialogCheckboxes.first().click();
+        await page.waitForTimeout(200);
+        await expect(moveBtn).not.toHaveAttribute('disabled');
+        await expect(copyBtn).not.toHaveAttribute('disabled');
+
+        await dialogCheckboxes.nth(1).click();
+        await page.waitForTimeout(200);
+        await expect(moveBtn).toHaveAttribute('disabled', '');  // >1 selected
+        await expect(copyBtn).not.toHaveAttribute('disabled');
+
+        await dialogCheckboxes.nth(1).click();
+        await page.waitForTimeout(200);
+        await expect(moveBtn).not.toHaveAttribute('disabled');  // back to 1
+      } else if (colCount === 1) {
+        await dialogCheckboxes.first().click();
+        await page.waitForTimeout(200);
+        await expect(moveBtn).not.toHaveAttribute('disabled');
+      }
+
+      await page.waitForTimeout(500);
+      await dialog.locator('sl-button[name="cancel"]').click();
+      await page.waitForTimeout(300);
+      await page.locator('sl-button[name="closeDrawer"]').click();
+      await performLogout(page);
+    } finally {
+      stopErrorMonitoring();
+    }
+  });
+
+  test('moving a document shows success notification and reloads the drawer', async ({ page }) => {
+    const consoleLogs = setupTestConsoleCapture(page);
+    const stopErrorMonitoring = setupErrorFailure(consoleLogs, ALLOWED_ERROR_PATTERNS);
+    try {
+      await navigateAndLogin(page, 'testadmin', 'adminpass');
+      await page.waitForTimeout(1000);
+
+      await page.locator('sl-button[name="fileDrawerTrigger"]').click();
+      await page.waitForTimeout(500);
+
+      const pdfItems = page.locator('.pdf-item');
+      if (await pdfItems.count() === 0) {
+        await page.locator('sl-button[name="closeDrawer"]').click();
+        return;
+      }
+
+      const firstPdfItem = pdfItems.first();
+      const sourceCollection = await firstPdfItem.getAttribute('data-collection');
+
+      await firstPdfItem.locator('sl-checkbox').click();
+      await page.waitForTimeout(300);
+      await page.locator('sl-button[name="moveCopyButton"]').click();
+      await page.waitForTimeout(500);
+
+      const dialog = page.locator('sl-dialog[name="moveFilesDialog"]');
+      await expect(dialog).toHaveAttribute('open', '');
+
+      const dialogCheckboxes = dialog.locator('[name="collectionsList"] sl-checkbox');
+      let targetSelected = false;
+      for (let i = 0; i < await dialogCheckboxes.count(); i++) {
+        const id = await dialogCheckboxes.nth(i).getAttribute('data-collection-id');
+        if (id && id !== sourceCollection) {
+          await dialogCheckboxes.nth(i).click();
+          await page.waitForTimeout(200);
+          targetSelected = true;
+          break;
+        }
+      }
+
+      if (!targetSelected) {
+        // Only one collection — can't move anywhere else
+        await dialog.locator('sl-button[name="cancel"]').click();
+        await page.locator('sl-button[name="closeDrawer"]').click();
+        return;
+      }
+
+      // Accept the confirm() dialog
+      page.once('dialog', async d => { await d.accept(); });
+
+      await page.waitForTimeout(500);
+      await dialog.locator('sl-button[name="moveBtn"]').click();
+      await page.waitForTimeout(1500);
+
+      await expect(page.locator('sl-alert[variant="success"]')).toBeVisible({ timeout: 5000 });
+
+      await page.locator('sl-button[name="closeDrawer"]').click();
+      await performLogout(page);
+    } finally {
+      stopErrorMonitoring();
+    }
+  });
+
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+npm run test:e2e -- tests/e2e/tests/file-drawer-batch-move.spec.js
+```
+
+Expected: all 5 tests pass (or skip gracefully when test data is absent).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/tests/file-drawer-batch-move.spec.js
+git commit -m "test(e2e): add batch move/copy drawer tests (closes #400)"
+```
+
+---
+
+## Final verification checklist
+
+Before declaring done:
+
+- [ ] No `#moveBtn` field or `addButton()` call in `move-files.js`
+- [ ] PDF items in the drawer tree each have a visible `sl-checkbox`
+- [ ] Checking a collection checkbox checks all its PDF item checkboxes (and vice versa)
+- [ ] Partially selecting docs within a collection shows collection checkbox as indeterminate
+- [ ] Move/copy button invisible for annotator role, visible for reviewer/admin
+- [ ] Move/copy button disabled when no docs checked, enabled when ≥1 checked
+- [ ] Dialog opens with collections grouped by project headers
+- [ ] Move button disabled when 0 or >1 collections checked; Copy button disabled only when 0
+- [ ] "New" button in dialog creates a collection and adds a checkbox immediately
+- [ ] Move: document disappears from source collection after drawer reloads
+- [ ] Copy: document appears in both source and target after drawer reloads
+- [ ] All 5 E2E tests pass

--- a/docs/superpowers/plans/2026-06-21-codemirror-theme-selector.md
+++ b/docs/superpowers/plans/2026-06-21-codemirror-theme-selector.md
@@ -1,0 +1,402 @@
+# CodeMirror Theme Selector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a palette-icon dropdown button to the XML editor toolbar (far right) that lets users switch between four CodeMirror editor themes (default, dark, color-blind-friendly, high-contrast), with the active theme checkmarked and the preference persisted via `uiStorage`.
+
+**Architecture:** A new `editor-themes.js` module defines four theme bundles as `{ id, label, extensions }` arrays ready for a CodeMirror `Compartment`. The `XMLEditor` module gains a `#themeCompartment` and a `setTheme()` method. The `xmleditor` plugin registers a new toolbar button template, builds the theme menu on install, and wires up selection persistence via `uiStorage`.
+
+**Tech Stack:** CodeMirror 6 (`@codemirror/language` `HighlightStyle`, `@codemirror/view` `EditorView`), `@lezer/highlight` `tags`, Shoelace `sl-dropdown`/`sl-menu`/`sl-menu-item`, existing plugin infrastructure (`uiStorage`, `registerTemplate`, `createSingleFromTemplate`, `addToolbarWidget`).
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+| --- | --- | --- |
+| Create | `app/src/modules/codemirror/editor-themes.js` | Four theme bundle definitions |
+| Modify | `app/src/modules/xmleditor.js` | Add `#themeCompartment` + `setTheme()` |
+| Create | `app/src/templates/xmleditor-theme-button.html` | Icon-only dropdown toolbar button template |
+| Modify | `app/src/plugins/xmleditor.js` | Register template, wire menu, persist preference |
+| Modify | `app/src/plugins/xmleditor.js` (typedef only) | Add `themeDropdown/Btn/Menu` to `xmlEditorToolbarPart` |
+
+---
+
+### Task 1: Create `editor-themes.js` module
+
+**Files:**
+- Create: `app/src/modules/codemirror/editor-themes.js`
+
+- [ ] **Step 1: Create the file with all four theme bundles**
+
+```javascript
+/**
+ * @import {Extension} from '@codemirror/state'
+ */
+
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { EditorView } from "@codemirror/view";
+import { tags } from "@lezer/highlight";
+
+/**
+ * @typedef {object} EditorTheme
+ * @property {string} id - Unique identifier used for persistence
+ * @property {string} label - Display label shown in the theme menu
+ * @property {Extension[]} extensions - CodeMirror extensions to load into the theme Compartment
+ */
+
+const defaultHighlight = HighlightStyle.define([
+  { tag: tags.tagName, color: "#0000c0", fontWeight: "bold" },
+  { tag: tags.angleBracket, color: "#0000c0" },
+  { tag: tags.attributeName, color: "#7d0000" },
+  { tag: tags.attributeValue, color: "#036103" },
+  { tag: tags.comment, color: "#808080", fontStyle: "italic" },
+  { tag: tags.processingInstruction, color: "#9b2d9b" },
+  { tag: tags.operator, color: "#555" },
+]);
+
+const darkHighlight = HighlightStyle.define([
+  { tag: tags.tagName, color: "#89b4fa", fontWeight: "bold" },
+  { tag: tags.angleBracket, color: "#89b4fa" },
+  { tag: tags.attributeName, color: "#f38ba8" },
+  { tag: tags.attributeValue, color: "#a6e3a1" },
+  { tag: tags.comment, color: "#6c7086", fontStyle: "italic" },
+  { tag: tags.processingInstruction, color: "#cba6f7" },
+  { tag: tags.operator, color: "#a6adc8" },
+]);
+
+const colorBlindHighlight = HighlightStyle.define([
+  { tag: tags.tagName, color: "#648fff", fontWeight: "bold" },
+  { tag: tags.angleBracket, color: "#648fff" },
+  { tag: tags.attributeName, color: "#dc267f" },
+  { tag: tags.attributeValue, color: "#009e73" },
+  { tag: tags.comment, color: "#767676", fontStyle: "italic" },
+  { tag: tags.processingInstruction, color: "#785ef0" },
+  { tag: tags.operator, color: "#555" },
+]);
+
+const highContrastHighlight = HighlightStyle.define([
+  { tag: tags.tagName, color: "#0000ff", fontWeight: "bold" },
+  { tag: tags.angleBracket, color: "#0000ff" },
+  { tag: tags.attributeName, color: "#cc0000" },
+  { tag: tags.attributeValue, color: "#006600" },
+  { tag: tags.comment, color: "#595959", fontStyle: "italic" },
+  { tag: tags.processingInstruction, color: "#7b00a3" },
+  { tag: tags.operator, color: "#333" },
+]);
+
+const darkViewTheme = EditorView.theme({
+  "&": { backgroundColor: "#1e1e2e", color: "#cdd6f4" },
+  ".cm-content": { caretColor: "#cdd6f4" },
+  ".cm-cursor": { borderLeftColor: "#cdd6f4" },
+  ".cm-gutters": { backgroundColor: "#181825", color: "#6c7086", border: "none" },
+  ".cm-activeLineGutter": { backgroundColor: "#1e1e2e" },
+  ".cm-activeLine": { backgroundColor: "#2a2a3d" },
+  ".cm-selectionBackground": { backgroundColor: "#45475a" },
+  "&.cm-focused .cm-selectionBackground": { backgroundColor: "#45475a" },
+  ".cm-foldPlaceholder": { backgroundColor: "#313244", color: "#cdd6f4", border: "none" },
+}, { dark: true });
+
+const lightViewTheme = EditorView.theme({
+  "&": { backgroundColor: "#ffffff", color: "#1e1e1e" },
+  ".cm-gutters": { backgroundColor: "#f5f5f5", color: "#999", border: "none" },
+});
+
+/** @type {EditorTheme[]} */
+export const THEMES = [
+  {
+    id: "default",
+    label: "Default (light)",
+    extensions: [lightViewTheme, syntaxHighlighting(defaultHighlight)],
+  },
+  {
+    id: "dark",
+    label: "Dark",
+    extensions: [darkViewTheme, syntaxHighlighting(darkHighlight)],
+  },
+  {
+    id: "colorBlind",
+    label: "Color-blind friendly",
+    extensions: [lightViewTheme, syntaxHighlighting(colorBlindHighlight)],
+  },
+  {
+    id: "highContrast",
+    label: "High contrast",
+    extensions: [lightViewTheme, syntaxHighlighting(highContrastHighlight)],
+  },
+];
+
+/**
+ * Look up a theme bundle by id, falling back to default.
+ * @param {string} id
+ * @returns {EditorTheme}
+ */
+export function getTheme(id) {
+  return THEMES.find(t => t.id === id) ?? THEMES[0];
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/src/modules/codemirror/editor-themes.js
+git commit -m "feat(themes): add editor-themes module with four CodeMirror theme bundles"
+```
+
+---
+
+### Task 2: Add `#themeCompartment` and `setTheme()` to `XMLEditor`
+
+**Files:**
+- Modify: `app/src/modules/xmleditor.js`
+
+**Context:** `XMLEditor` already uses private `Compartment` fields (lines 157–167) and the `setLineWrapping` method (line 793) as the reference pattern. All compartments are initialised in the `extensions` array passed to `EditorState.create()` (lines 191–231). `@codemirror/language` is already imported on line 48. `EditorView` is already imported on line 46.
+
+- [ ] **Step 1: Import `getTheme` and `EditorTheme` typedef at the top of the file**
+
+After the existing local imports (around line 60), add:
+
+```javascript
+import { getTheme } from './codemirror/editor-themes.js';
+/**
+ * @import {EditorTheme} from './codemirror/editor-themes.js'
+ */
+```
+
+- [ ] **Step 2: Add `#themeCompartment` to the compartment block (lines 157–167)**
+
+Insert after `#xmlTagSyncCompartment`:
+
+```javascript
+  #themeCompartment = new Compartment()
+```
+
+- [ ] **Step 3: Replace the `syntaxHighlighting(defaultHighlightStyle, { fallback: true })` line in the extensions array (line 201) with the compartment initialisation**
+
+Old line:
+```javascript
+      syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+```
+
+New line:
+```javascript
+      this.#themeCompartment.of(getTheme('default').extensions),
+```
+
+Also remove `defaultHighlightStyle` from the `@codemirror/language` import on line 48 since it is no longer used directly (to keep imports clean):
+
+Old:
+```javascript
+import { syntaxTree, syntaxParserRunning, indentUnit, foldInside, foldEffect, unfoldEffect, foldGutter, foldKeymap, indentOnInput, syntaxHighlighting, defaultHighlightStyle, bracketMatching } from "@codemirror/language"
+```
+
+New:
+```javascript
+import { syntaxTree, syntaxParserRunning, indentUnit, foldInside, foldEffect, unfoldEffect, foldGutter, foldKeymap, indentOnInput, syntaxHighlighting, bracketMatching } from "@codemirror/language"
+```
+
+- [ ] **Step 4: Add the `setTheme()` public method immediately after `setLineWrapping()` (around line 805)**
+
+```javascript
+  /**
+   * Replaces the active editor theme bundle.
+   * @param {EditorTheme} theme
+   */
+  setTheme(theme) {
+    this.#view.dispatch({
+      effects: this.#themeCompartment.reconfigure(theme.extensions)
+    });
+  }
+```
+
+- [ ] **Step 5: Verify no import of `defaultHighlightStyle` remains and that `syntaxHighlighting` is still imported**
+
+```bash
+grep "defaultHighlightStyle\|syntaxHighlighting" app/src/modules/xmleditor.js
+```
+
+Expected output: one line containing `syntaxHighlighting` in the import, none with `defaultHighlightStyle`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/modules/xmleditor.js
+git commit -m "feat(themes): add #themeCompartment and setTheme() to XMLEditor"
+```
+
+---
+
+### Task 3: Create the theme button toolbar template
+
+**Files:**
+- Create: `app/src/templates/xmleditor-theme-button.html`
+
+**Context:** Follows the exact same structure as `app/src/templates/xsl-viewer-button.html`. The `sl-tooltip` wraps `sl-dropdown`, which contains the icon-only trigger button (slot="trigger") and an empty `sl-menu` whose items are built programmatically. The `name` attributes are referenced in the plugin via `querySelector`.
+
+- [ ] **Step 1: Create the template file**
+
+```html
+<sl-tooltip content="Editor theme">
+  <sl-dropdown name="themeDropdown" placement="bottom-end">
+    <sl-button name="themeBtn" variant="text" size="small" slot="trigger">
+      <sl-icon name="palette"></sl-icon>
+    </sl-button>
+    <sl-menu name="themeMenu"></sl-menu>
+  </sl-dropdown>
+</sl-tooltip>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/src/templates/xmleditor-theme-button.html
+git commit -m "feat(themes): add xmleditor-theme-button toolbar template"
+```
+
+---
+
+### Task 4: Wire the theme button into the XML editor plugin
+
+**Files:**
+- Modify: `app/src/plugins/xmleditor.js`
+
+**Context:**
+- `createSingleFromTemplate` is already imported from `'../modules/ui-system.js'` (line 30).
+- `registerTemplate` is imported from the same module (line 30).
+- The existing `xsl-viewer` plugin (lines 126–147) shows the exact pattern for adding a dropdown widget: `createSingleFromTemplate` → `addToolbarWidget(el, priority)` → `querySelector` for inner elements → z-index fix with `sl-show`/`sl-hide`.
+- `uiStorage` is available on every `Plugin` subclass as `this.uiStorage`.
+- `THEMES` and `getTheme` come from `'../modules/codemirror/editor-themes.js'`.
+- Priority 1 (lower than download's 2) ensures the theme button is the rightmost toolbar item.
+
+- [ ] **Step 1: Add `@import` for `EditorTheme` and import `THEMES`/`getTheme` near the top of `app/src/plugins/xmleditor.js`**
+
+After the existing imports (around line 37), add:
+
+```javascript
+import { THEMES, getTheme } from '../modules/codemirror/editor-themes.js';
+/**
+ * @import {EditorTheme} from '../modules/codemirror/editor-themes.js'
+ * @import {SlMenuItem} from '../ui.js'
+ */
+```
+
+Note: `SlMenuItem` may already be imported — check line 11 first and skip if present.
+
+- [ ] **Step 2: Register the theme button template at module level (after the other `registerTemplate` calls, around line 53)**
+
+```javascript
+await registerTemplate('xmleditor-theme-button', 'xmleditor-theme-button.html')
+```
+
+- [ ] **Step 3: Add private field declarations for theme UI elements in the `XmlEditorPlugin` class body, after the existing `#downloadBtn` field (around line 167)**
+
+```javascript
+  /** @type {import('../ui.js').SlDropdown|null} */
+  #themeDropdown = null;
+  /** @type {import('../ui.js').SlMenu|null} */
+  #themeMenu = null;
+```
+
+- [ ] **Step 4: In the `install()` method, add theme button setup after the import/export buttons block (after the `importExportButtons.forEach` block, around line 311)**
+
+```javascript
+    // Create theme selector button and add to toolbar (priority 1 - far right)
+    const themeButtonEl = createSingleFromTemplate('xmleditor-theme-button');
+    this.#toolbar.add(themeButtonEl, 1);
+
+    this.#themeDropdown = /** @type {import('../ui.js').SlDropdown} */ (themeButtonEl.querySelector('[name="themeDropdown"]'));
+    this.#themeMenu = /** @type {import('../ui.js').SlMenu} */ (themeButtonEl.querySelector('[name="themeMenu"]'));
+
+    // Build theme menu items
+    const savedThemeId = this.uiStorage.get('editorTheme', 'default');
+    for (const theme of THEMES) {
+      const item = /** @type {import('../ui.js').SlMenuItem} */ (document.createElement('sl-menu-item'));
+      item.textContent = theme.label;
+      item.dataset.themeId = theme.id;
+      item.type = 'checkbox';
+      item.checked = theme.id === savedThemeId;
+      this.#themeMenu.appendChild(item);
+    }
+
+    // Apply saved theme to the editor
+    this.#xmlEditor.setTheme(getTheme(savedThemeId));
+
+    // Theme selection handler
+    this.#themeMenu.addEventListener('sl-select', (event) => {
+      const item = /** @type {import('../ui.js').SlMenuItem} */ (event.detail.item);
+      const themeId = item.dataset.themeId;
+      if (!themeId) return;
+      this.#xmlEditor.setTheme(getTheme(themeId));
+      this.uiStorage.set('editorTheme', themeId);
+      // Update checkmarks
+      this.#themeMenu.querySelectorAll('sl-menu-item').forEach(el => {
+        /** @type {import('../ui.js').SlMenuItem} */ (el).checked = el.dataset.themeId === themeId;
+      });
+    });
+
+    // Fix z-index stacking context so the dropdown appears above the editor
+    if (this.#themeDropdown) {
+      this.#themeDropdown.addEventListener('sl-show', () => {
+        this.#themeDropdown.closest('tool-bar')?.classList.add('dropdown-open');
+      });
+      this.#themeDropdown.addEventListener('sl-hide', () => {
+        this.#themeDropdown.closest('tool-bar')?.classList.remove('dropdown-open');
+      });
+    }
+```
+
+- [ ] **Step 5: Add the typedef entries to `xmlEditorToolbarPart` (around line 70–87)**
+
+In the `@typedef {object} xmlEditorToolbarPart` block, add these three lines before the closing `*/`:
+
+```javascript
+ * @property {import('./xsl-viewer.js').SlDropdown} themeDropdown - Editor theme picker dropdown
+ * @property {import('../ui.js').SlButton} themeBtn - Editor theme picker trigger button
+ * @property {import('../ui.js').SlMenu} themeMenu - Editor theme picker menu
+```
+
+(Use the same `SlDropdown`/`SlMenu` types already present in the file. The exact import path to use is whatever is already used for `xslViewerDropdown` in the same typedef — around line 82.)
+
+- [ ] **Step 6: Verify the theme button appears and works**
+
+Open the running app (do NOT restart it — the dev server auto-reloads). Open any XML file. Confirm:
+1. A palette icon (`🎨`) appears as the rightmost toolbar button.
+2. Clicking it shows a dropdown with four items.
+3. The active theme has a checkmark.
+4. Selecting "Dark" switches the editor to a dark background with light syntax colors.
+5. Refreshing the page restores the last selected theme.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/plugins/xmleditor.js
+git commit -m "feat(themes): add editor theme selector dropdown to XML editor toolbar"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Requirement | Task |
+| --- | --- |
+| Four themes (default, dark, colorBlind, highContrast) | Task 1 |
+| Editor background controlled by theme | Task 1 (`EditorView.theme`) |
+| XML syntax color palette per theme | Task 1 (`HighlightStyle.define`) |
+| CodeMirror Compartment for runtime swap | Task 2 |
+| `setTheme()` public method on `XMLEditor` | Task 2 |
+| Icon-only button in XML editor toolbar, right side | Task 3 + Task 4 |
+| Dropdown with theme names | Task 4 |
+| Active theme checkmarked | Task 4 |
+| Preference persisted via `uiStorage` | Task 4 |
+| Restored on page load | Task 4 |
+| Typedef updated | Task 4 step 5 |
+
+**Placeholder scan:** No TBDs, TODOs, or vague steps found.
+
+**Type consistency:**
+- `EditorTheme` defined in Task 1, imported in Tasks 2 and 4 using the same path.
+- `getTheme(id)` returns `EditorTheme`, called in Task 2 and Task 4 with string literal or stored id — consistent.
+- `#themeCompartment.reconfigure(theme.extensions)` — `theme.extensions` is `Extension[]`, which is what `Compartment.reconfigure` expects — consistent.
+- `THEMES` iterated in Task 4 to build menu; `getTheme` used to look up by stored id — consistent with Task 1 export names.

--- a/docs/superpowers/specs/2026-06-21-batch-move-copy-design.md
+++ b/docs/superpowers/specs/2026-06-21-batch-move-copy-design.md
@@ -1,0 +1,156 @@
+# Batch Move/Copy — Issue #400
+
+## Goal
+
+Replace the single-document toolbar Move/Copy button with a batch operation driven from the
+Collection & Files Drawer. Users select any number of documents via per-document checkboxes
+in the file tree, then invoke a Move/Copy dialog that shows all accessible collections
+grouped by project.
+
+---
+
+## Architecture
+
+### 1. `move-files.js` (MoveFilesPlugin) — repurposed as a service plugin
+
+**Remove:**
+- `#moveBtn` field and all toolbar button creation
+- Call to `this.#documentActions.addButton()`
+- `onStateUpdate()` (no longer needed)
+- `document-actions` dependency
+
+**Add:**
+- Public `async showBatchDialog({ documents, fileData, collections, projects })` method
+  - `documents`: `Array<{pdfId: string, xmlId: string|null}>` — documents to act on
+  - `fileData`: current state file data (for context)
+  - `collections`: accessible collection objects
+  - `projects`: project objects for grouping
+- Method populates the redesigned dialog and resolves to
+  `{ action: 'move'|'copy', targetCollections: string[] }` or `null` on cancel
+- Move button disabled when 0 or >1 collections are checked in the dialog
+- Copy button disabled when 0 collections are checked
+- "New collection" button retained
+
+**Keep:** dialog creation in `install()`, `#newCollectionBtn` handler, `#client` accessor.
+
+### 2. `move-files-dialog.html` — redesigned
+
+**Replace** the `sl-select` + `sl-checkbox[copyMode]` + single submit layout with:
+
+```html
+<sl-dialog name="moveFilesDialog" label="Move/Copy to Collection">
+  <p>Select target collection(s) for the <span name="docCount">N</span> selected document(s).</p>
+  <div name="collectionsList" style="max-height: 300px; overflow-y: auto;">
+    <!-- Dynamically populated: project headers + per-collection sl-checkbox -->
+  </div>
+  <sl-button slot="footer" name="newCollectionBtn" variant="default" outline>
+    <sl-icon name="plus-lg" slot="prefix"></sl-icon> New
+  </sl-button>
+  <sl-button slot="footer" name="cancel">Cancel</sl-button>
+  <sl-button slot="footer" name="moveBtn" variant="primary" disabled>Move</sl-button>
+  <sl-button slot="footer" name="copyBtn" variant="default" disabled>Copy</sl-button>
+</sl-dialog>
+```
+
+The `collectionsList` container is populated dynamically:
+- Project name as a bold heading (or "No project")
+- `sl-checkbox` per collection beneath each heading
+- Checking/unchecking a collection updates button enabled states
+
+### 3. `file-selection-drawer.js` (FileSelectionDrawerPlugin) — extended
+
+**New private state:**
+```js
+#selectedDocuments = new Set()  // PDF stable_ids
+```
+
+**In `#buildCollectionTreeItem()`:** after creating each `pdfItem`, insert a `sl-checkbox`
+before the icon+label content. The checkbox's `sl-change` event calls
+`#onDocumentCheckboxChange(pdfStableId, checked, collectionName)`.
+
+**Collection ↔ document sync:**
+- `#onCollectionCheckboxChange()` additionally checks/unchecks all `pdfItem` checkboxes
+  in the collection subtree and updates `#selectedDocuments`.
+- `#onDocumentCheckboxChange()` updates `#selectedDocuments`, then recalculates the
+  parent collection checkbox state (checked / indeterminate / unchecked) and calls
+  `#updateMoveCopyButtonState()`.
+
+**New footer button:** `moveCopyButton` (icon-only, `folder-symlink`, enabled when
+`#selectedDocuments.size > 0`).
+
+**Move/copy execution:**
+1. Build `documents` array: for each PDF stable_id in `#selectedDocuments`, find the
+   gold-standard artifact (or first artifact) in `state.fileData` to obtain `xmlId`.
+2. Call `this.getDependency('move-files').showBatchDialog({ documents, ... })`.
+3. On non-null result, show a confirmation: e.g.
+   "Move 3 documents to 'TargetCollection'? This cannot be undone." (Move)
+   or "Copy 3 documents to 2 collections?" (Copy).
+4. Show spinner; iterate documents, calling `client.apiClient.filesMove(...)` or
+   `client.apiClient.filesCopy(...)` for each.
+5. On completion, clear `#selectedDocuments`, call `getDependency('filedata').reload({ refresh: true })`,
+   and show a success notification.
+6. On error, report per-document failures without aborting remaining documents.
+
+### 4. `file-selection-drawer.html` — extended
+
+Add to the footer (alongside import/export/delete/new buttons):
+
+```html
+<sl-tooltip content="Move or copy selected documents to a collection">
+  <sl-button name="moveCopyButton" variant="default" size="small" disabled>
+    <sl-icon name="folder-symlink"></sl-icon>
+  </sl-button>
+</sl-tooltip>
+```
+
+### 5. Type files updated
+
+- `move-files-dialog.types.js` — manual update to match redesigned HTML
+- `file-selection-drawer.types.js` — add `moveCopyButton` to `fileDrawerPart`
+
+### 6. `tests/e2e/tests/file-drawer-batch-move.spec.js` — new test
+
+Covers:
+1. Login as reviewer
+2. Open the drawer; verify per-document checkboxes exist on PDF items
+3. Check two documents
+4. Click the Move/Copy button; verify dialog opens with collection checkboxes
+5. Select one collection; verify Move button is enabled
+6. Select a second collection; verify Move button is disabled, Copy still enabled
+7. De-select to one collection; click Move; confirm dialog; verify success notification
+8. Reload the drawer; verify moved documents appear in the target collection
+
+---
+
+## Constraints
+
+- `#selectedDocuments` tracks PDF stable_ids only; collection checkboxes remain the
+  source of truth for export/delete (no cross-contamination).
+- The existing `#selectedCollections` set (export/delete) is not changed by document
+  checkbox interactions.
+- `MoveFilesPlugin` no longer has `onStateUpdate` — the drawer's `#updateMoveCopyButtonState`
+  controls the button instead.
+- `filesMove` / `filesCopy` API calls use `pdf_id` (stable_id) and `xml_id` (first gold
+  or first artifact, or the same stable_id if no artifact available). The backend ignores
+  `xml_id` for the actual move but the field is required.
+- The `move-files` dependency is added to `FileSelectionDrawerPlugin`'s `deps` array
+  only after verifying no circular dependency exists (move-files → services, file-selection,
+  logger, dialog; none of these lead back to file-selection-drawer).
+- `#isUpdatingTree` flag is not set when building/updating document checkboxes
+  (document checkboxes are not `sl-tree-item` selection — they are separate widgets).
+- `#selectedDocuments` is cleared at the start of `#populateFileTree()` (tree rebuild
+  resets all checkboxes to unchecked, so the selection set must match).
+
+---
+
+## Files Changed
+
+| File | Type |
+| --- | --- |
+| `app/src/plugins/move-files.js` | modify |
+| `app/src/templates/move-files-dialog.html` | modify |
+| `app/src/templates/move-files-dialog.types.js` | modify |
+| `app/src/plugins/file-selection-drawer.js` | modify |
+| `app/src/templates/file-selection-drawer.html` | modify |
+| `app/src/templates/file-selection-drawer.types.js` | modify (if auto-generated; else update manually) |
+| `tests/e2e/tests/file-drawer-batch-move.spec.js` | new |

--- a/docs/superpowers/specs/2026-06-21-batch-move-copy-design.md
+++ b/docs/superpowers/specs/2026-06-21-batch-move-copy-design.md
@@ -130,9 +130,8 @@ Covers:
   checkbox interactions.
 - `MoveFilesPlugin` no longer has `onStateUpdate` — the drawer's `#updateMoveCopyButtonState`
   controls the button instead.
-- `filesMove` / `filesCopy` API calls use `pdf_id` (stable_id) and `xml_id` (first gold
-  or first artifact, or the same stable_id if no artifact available). The backend ignores
-  `xml_id` for the actual move but the field is required.
+- `filesMove` / `filesCopy` API calls only require `pdf_id` and `destination_collection`.
+  `xml_id` has been removed — operations always act on the PDF and all associated TEI files atomically.
 - The `move-files` dependency is added to `FileSelectionDrawerPlugin`'s `deps` array
   only after verifying no circular dependency exists (move-files → services, file-selection,
   logger, dialog; none of these lead back to file-selection-drawer).

--- a/fastapi_app/lib/models/models_files.py
+++ b/fastapi_app/lib/models/models_files.py
@@ -149,28 +149,24 @@ class DeleteFilesResponse(BaseModel):
 
 class MoveFilesRequest(BaseModel):
     """Request for POST /api/files/move"""
-    pdf_id: str         # Hash or stable_id
-    xml_id: str         # Hash or stable_id
+    pdf_id: str                  # Hash or stable_id
     destination_collection: str
 
 
 class MoveFilesResponse(BaseModel):
     """Response for POST /api/files/move"""
     new_pdf_id: str
-    new_xml_id: str
 
 
 class CopyFilesRequest(BaseModel):
     """Request for POST /api/files/copy"""
-    pdf_id: str         # Hash or stable_id
-    xml_id: str         # Hash or stable_id
+    pdf_id: str                  # Hash or stable_id
     destination_collection: str
 
 
 class CopyFilesResponse(BaseModel):
     """Response for POST /api/files/copy"""
     new_pdf_id: str
-    new_xml_id: str
 
 
 class GetLocksResponse(BaseModel):

--- a/fastapi_app/routers/files_copy.py
+++ b/fastapi_app/routers/files_copy.py
@@ -97,8 +97,4 @@ def copy_files(
             f"Document {pdf_file.doc_id} already in collection {body.destination_collection}"
         )
 
-    # Return stable_id (short, permanent ID) for client use
-    return CopyFilesResponse(
-        new_pdf_id=pdf_file.stable_id,
-        new_xml_id=body.xml_id  # XML ID unchanged
-    )
+    return CopyFilesResponse(new_pdf_id=pdf_file.stable_id)

--- a/fastapi_app/routers/files_move.py
+++ b/fastapi_app/routers/files_move.py
@@ -107,8 +107,4 @@ def move_files(
             f"Document {pdf_file.doc_id} already in collection {body.destination_collection}"
         )
 
-    # Return IDs (stable_id, unchanged)
-    return MoveFilesResponse(
-        new_pdf_id=pdf_file.stable_id,
-        new_xml_id=body.xml_id  # XML ID unchanged
-    )
+    return MoveFilesResponse(new_pdf_id=pdf_file.stable_id)

--- a/tests/api/v1/files_copy.test.js
+++ b/tests/api/v1/files_copy.test.js
@@ -69,12 +69,10 @@ describe('File Copy API E2E Tests', { concurrency: 1 }, () => {
     // Copy files to new collection using hashes from setup
     const result = await authenticatedApiCall(session.sessionId, '/files/copy', 'POST', {
       pdf_id: testState.pdfHash,
-      xml_id: testState.teiHash,
       destination_collection: testState.destinationCollection
     }, BASE_URL);
 
     assert(result.new_pdf_id, 'Should return new PDF ID');
-    assert(result.new_xml_id, 'Should return new XML ID');
 
     // Verify file is now in both collections
     const updatedFileList = await authenticatedApiCall(session.sessionId, '/files/list', 'GET', null, BASE_URL);
@@ -88,7 +86,7 @@ describe('File Copy API E2E Tests', { concurrency: 1 }, () => {
     }
     assert(copiedDoc.collections.includes(testState.destinationCollection), 'Should be in destination collection');
 
-    logger.success(`Files copied successfully: PDF=${result.new_pdf_id}, XML=${result.new_xml_id}`);
+    logger.success(`Files copied successfully: PDF=${result.new_pdf_id}`);
   });
 
   test('POST /api/v1/files/copy should support abbreviated hashes', async () => {
@@ -102,12 +100,10 @@ describe('File Copy API E2E Tests', { concurrency: 1 }, () => {
     // Copy using abbreviated hashes
     const result = await authenticatedApiCall(session.sessionId, '/files/copy', 'POST', {
       pdf_id: testState.pdfHash,
-      xml_id: testState.teiHash,
       destination_collection: 'another-collection'
     }, BASE_URL);
 
     assert(result.new_pdf_id, 'Should return new PDF ID');
-    assert(result.new_xml_id, 'Should return new XML ID');
 
     logger.success('Copy with abbreviated hashes successful');
   });
@@ -123,12 +119,10 @@ describe('File Copy API E2E Tests', { concurrency: 1 }, () => {
     // Try to copy to same collection again (should be idempotent)
     const result = await authenticatedApiCall(session.sessionId, '/files/copy', 'POST', {
       pdf_id: testState.pdfHash,
-      xml_id: testState.teiHash,
       destination_collection: 'another-collection'
     }, BASE_URL);
 
     assert(result.new_pdf_id, 'Should return new PDF ID even if already in collection');
-    assert(result.new_xml_id, 'Should return new XML ID even if already in collection');
 
     logger.success('Duplicate collection copy handled gracefully');
   });
@@ -139,7 +133,6 @@ describe('File Copy API E2E Tests', { concurrency: 1 }, () => {
     try {
       await authenticatedApiCall(session.sessionId, '/files/copy', 'POST', {
         pdf_id: 'nonexistenthash123',
-        xml_id: testState.teiHash || 'somehash',
         destination_collection: 'test-dest'
       }, BASE_URL);
 
@@ -156,7 +149,7 @@ describe('File Copy API E2E Tests', { concurrency: 1 }, () => {
     try {
       await authenticatedApiCall(session.sessionId, '/files/copy', 'POST', {
         pdf_id: 'somehash'
-        // Missing xml_id and destination_collection
+        // Missing destination_collection
       }, BASE_URL);
 
       assert.fail('Should have thrown validation error');

--- a/tests/api/v1/files_move.test.js
+++ b/tests/api/v1/files_move.test.js
@@ -112,12 +112,10 @@ describe('File Move API E2E Tests', { concurrency: 1 }, () => {
     // Move files to new collection using hashes from setup
     const result = await authenticatedApiCall(session.sessionId, '/files/move', 'POST', {
       pdf_id: testState.pdfHash,
-      xml_id: testState.teiHash,
       destination_collection: testState.destinationCollection
     }, BASE_URL);
 
     assert(result.new_pdf_id, 'Should return new PDF ID');
-    assert(result.new_xml_id, 'Should return new XML ID');
 
     // Verify file is now only in destination collection
     const fileList = await authenticatedApiCall(session.sessionId, '/files/list', 'GET', null, BASE_URL);
@@ -125,7 +123,7 @@ describe('File Move API E2E Tests', { concurrency: 1 }, () => {
     assert(movedDoc, 'Document should still exist');
     assert(movedDoc.collections.includes(testState.destinationCollection), 'Should be in destination collection');
 
-    logger.success(`Files moved successfully: PDF=${result.new_pdf_id}, XML=${result.new_xml_id}`);
+    logger.success(`Files moved successfully: PDF=${result.new_pdf_id}`);
   });
 
   test('POST /api/files/move should also move all TEI files for the document', async () => {
@@ -165,9 +163,8 @@ describe('File Move API E2E Tests', { concurrency: 1 }, () => {
     // Use a different collection than the first test (_inbox) to verify all TEI files are moved
     const newCollection = 'default';
 
-    const result = await authenticatedApiCall(session.sessionId, '/files/move', 'POST', {
+    await authenticatedApiCall(session.sessionId, '/files/move', 'POST', {
       pdf_id: testState.pdfHash,
-      xml_id: saveResp.file_id,
       destination_collection: newCollection
     }, BASE_URL);
 
@@ -200,12 +197,10 @@ describe('File Move API E2E Tests', { concurrency: 1 }, () => {
     // Move using abbreviated hashes
     const result = await authenticatedApiCall(session.sessionId, '/files/move', 'POST', {
       pdf_id: testState.pdfHash,
-      xml_id: testState.teiHash,
       destination_collection: 'another-collection'
     }, BASE_URL);
 
     assert(result.new_pdf_id, 'Should return new PDF ID');
-    assert(result.new_xml_id, 'Should return new XML ID');
 
     logger.success('Move with abbreviated hashes successful');
   });
@@ -221,12 +216,10 @@ describe('File Move API E2E Tests', { concurrency: 1 }, () => {
     // Try to move to same collection again (should be idempotent)
     const result = await authenticatedApiCall(session.sessionId, '/files/move', 'POST', {
       pdf_id: testState.pdfHash,
-      xml_id: testState.teiHash,
       destination_collection: 'another-collection'
     }, BASE_URL);
 
     assert(result.new_pdf_id, 'Should return new PDF ID even if already in collection');
-    assert(result.new_xml_id, 'Should return new XML ID even if already in collection');
 
     logger.success('Duplicate collection move handled gracefully');
   });
@@ -237,7 +230,6 @@ describe('File Move API E2E Tests', { concurrency: 1 }, () => {
     try {
       await authenticatedApiCall(session.sessionId, '/files/move', 'POST', {
         pdf_id: 'nonexistenthash123',
-        xml_id: testState.teiHash || 'somehash',
         destination_collection: 'test-dest'
       }, BASE_URL);
 
@@ -254,7 +246,7 @@ describe('File Move API E2E Tests', { concurrency: 1 }, () => {
     try {
       await authenticatedApiCall(session.sessionId, '/files/move', 'POST', {
         pdf_id: 'somehash'
-        // Missing xml_id and destination_collection
+        // Missing destination_collection
       }, BASE_URL);
 
       assert.fail('Should have thrown validation error');

--- a/tests/e2e/tests/file-drawer-batch-move.spec.js
+++ b/tests/e2e/tests/file-drawer-batch-move.spec.js
@@ -1,0 +1,387 @@
+/**
+ * E2E tests for batch move/copy feature in the file selection drawer.
+ *
+ * @testCovers app/src/plugins/file-selection-drawer.js
+ * @testCovers app/src/plugins/move-files.js
+ */
+
+import { test, expect } from '../fixtures/debug-on-failure.js';
+import { setupTestConsoleCapture, setupErrorFailure } from './helpers/test-logging.js';
+import { navigateAndLogin, performLogout } from './helpers/login-helper.js';
+
+// Define allowed error patterns
+const ALLOWED_ERROR_PATTERNS = [
+  'Failed to load resource.*404',
+  'Failed to load resource.*401.*UNAUTHORIZED',
+  'Failed to load resource.*400.*BAD REQUEST',
+  'Failed to load resource.*ERR_NETWORK_IO_SUSPENDED',
+  'offsetParent is not set.*cannot scroll'
+];
+
+// Test user with reviewer role (needed to see moveCopyButton)
+const TEST_REVIEWER = { username: 'testreviewer', password: 'reviewerpass' };
+
+/**
+ * Expands all collection items in the file tree so their pdf-item children become visible.
+ * sl-tree-item children are hidden (in a slot) when the item is collapsed, making their
+ * checkboxes invisible to Playwright. This helper programmatically expands all collection
+ * items so pdf-item checkboxes become interactable.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+async function expandAllCollections(page) {
+  const collectionItems = page.locator('.collection-item');
+  const count = await collectionItems.count();
+  for (let i = 0; i < count; i++) {
+    await collectionItems.nth(i).evaluate(el => { /** @type {any} */(el).expanded = true; });
+  }
+  await page.waitForTimeout(300);
+}
+
+test.describe('File Drawer Batch Move/Copy', () => {
+
+  test('document checkboxes appear on PDF items in the file drawer', async ({ page }) => {
+    const consoleLogs = setupTestConsoleCapture(page);
+    const stopErrorMonitoring = setupErrorFailure(consoleLogs, ALLOWED_ERROR_PATTERNS);
+
+    try {
+      await navigateAndLogin(page, TEST_REVIEWER.username, TEST_REVIEWER.password);
+      await page.waitForTimeout(1000);
+
+      // Open file drawer
+      const drawerTrigger = page.locator('sl-button[name="fileDrawerTrigger"]');
+      await drawerTrigger.click();
+      await page.waitForTimeout(500);
+
+      // Verify drawer is open
+      const drawer = page.locator('sl-drawer[name="fileDrawer"]');
+      await expect(drawer).toHaveAttribute('open', '');
+      await page.waitForTimeout(300);
+
+      // Check if any PDF items exist
+      const pdfItems = page.locator('.pdf-item');
+      const pdfCount = await pdfItems.count();
+      if (pdfCount === 0) {
+        // No test data — skip gracefully
+        const closeButton = page.locator('sl-button[name="closeDrawer"]');
+        await closeButton.click();
+        await page.waitForTimeout(300);
+        await performLogout(page);
+        return;
+      }
+
+      // Expand collections so pdf-item checkboxes become visible
+      await expandAllCollections(page);
+
+      // First pdf-item should contain a visible sl-checkbox
+      const firstPdfCheckbox = pdfItems.first().locator('sl-checkbox');
+      await expect(firstPdfCheckbox).toBeVisible();
+
+      // moveCopyButton should be visible (reviewer role makes it visible)
+      const moveCopyButton = page.locator('sl-button[name="moveCopyButton"]');
+      await expect(moveCopyButton).toBeVisible();
+
+      // moveCopyButton should be disabled (no docs selected yet)
+      await expect(moveCopyButton).toHaveAttribute('disabled', '');
+
+      // Close drawer
+      const closeButton = page.locator('sl-button[name="closeDrawer"]');
+      await closeButton.click();
+      await page.waitForTimeout(300);
+
+      await performLogout(page);
+    } finally {
+      stopErrorMonitoring();
+    }
+  });
+
+  test('checking a document checkbox enables the move/copy button', async ({ page }) => {
+    const consoleLogs = setupTestConsoleCapture(page);
+    const stopErrorMonitoring = setupErrorFailure(consoleLogs, ALLOWED_ERROR_PATTERNS);
+
+    try {
+      await navigateAndLogin(page, TEST_REVIEWER.username, TEST_REVIEWER.password);
+      await page.waitForTimeout(1000);
+
+      // Open file drawer
+      const drawerTrigger = page.locator('sl-button[name="fileDrawerTrigger"]');
+      await drawerTrigger.click();
+      await page.waitForTimeout(500);
+
+      const pdfItems = page.locator('.pdf-item');
+      const pdfCount = await pdfItems.count();
+      if (pdfCount === 0) {
+        const closeButton = page.locator('sl-button[name="closeDrawer"]');
+        await closeButton.click();
+        await page.waitForTimeout(300);
+        await performLogout(page);
+        return;
+      }
+
+      // Expand collections so pdf-item checkboxes become visible
+      await expandAllCollections(page);
+
+      const moveCopyButton = page.locator('sl-button[name="moveCopyButton"]');
+
+      // Should be disabled initially
+      await expect(moveCopyButton).toHaveAttribute('disabled', '');
+
+      // Click the first pdf-item's checkbox
+      const firstPdfCheckbox = pdfItems.first().locator('sl-checkbox');
+      await firstPdfCheckbox.click();
+      await page.waitForTimeout(300);
+
+      // moveCopyButton should now be enabled
+      await expect(moveCopyButton).not.toHaveAttribute('disabled');
+
+      // Click the same checkbox again to uncheck
+      await firstPdfCheckbox.click();
+      await page.waitForTimeout(300);
+
+      // moveCopyButton should be disabled again
+      await expect(moveCopyButton).toHaveAttribute('disabled', '');
+
+      // Close drawer
+      const closeButton = page.locator('sl-button[name="closeDrawer"]');
+      await closeButton.click();
+      await page.waitForTimeout(300);
+
+      await performLogout(page);
+    } finally {
+      stopErrorMonitoring();
+    }
+  });
+
+  test('collection checkbox toggles all document checkboxes and move/copy button', async ({ page }) => {
+    const consoleLogs = setupTestConsoleCapture(page);
+    const stopErrorMonitoring = setupErrorFailure(consoleLogs, ALLOWED_ERROR_PATTERNS);
+
+    try {
+      await navigateAndLogin(page, TEST_REVIEWER.username, TEST_REVIEWER.password);
+      await page.waitForTimeout(1000);
+
+      // Open file drawer
+      const drawerTrigger = page.locator('sl-button[name="fileDrawerTrigger"]');
+      await drawerTrigger.click();
+      await page.waitForTimeout(500);
+
+      const collectionItems = page.locator('.collection-item');
+      const collectionCount = await collectionItems.count();
+      if (collectionCount === 0) {
+        const closeButton = page.locator('sl-button[name="closeDrawer"]');
+        await closeButton.click();
+        await page.waitForTimeout(300);
+        await performLogout(page);
+        return;
+      }
+
+      // Find a collection that has pdf-items; use the first one that does
+      let firstCollectionWithPdfs = null;
+      let pdfCheckboxCount = 0;
+      for (let i = 0; i < collectionCount; i++) {
+        const item = collectionItems.nth(i);
+        const count = await item.locator('.pdf-item sl-checkbox').count();
+        if (count > 0) {
+          firstCollectionWithPdfs = item;
+          pdfCheckboxCount = count;
+          break;
+        }
+      }
+
+      if (!firstCollectionWithPdfs || pdfCheckboxCount === 0) {
+        const closeButton = page.locator('sl-button[name="closeDrawer"]');
+        await closeButton.click();
+        await page.waitForTimeout(300);
+        await performLogout(page);
+        return;
+      }
+
+      const moveCopyButton = page.locator('sl-button[name="moveCopyButton"]');
+      const pdfCheckboxesInCollection = firstCollectionWithPdfs.locator('.pdf-item sl-checkbox');
+
+      // Get the collection-level checkbox (first sl-checkbox directly in collection-item, not in pdf-item)
+      const collectionCheckbox = firstCollectionWithPdfs.locator('sl-checkbox').first();
+
+      // Check the collection checkbox
+      await collectionCheckbox.click();
+      await page.waitForTimeout(300);
+
+      // All pdf-item checkboxes in that collection should now be checked
+      for (let i = 0; i < pdfCheckboxCount; i++) {
+        await expect(pdfCheckboxesInCollection.nth(i)).toHaveJSProperty('checked', true);
+      }
+
+      // moveCopyButton should be enabled
+      await expect(moveCopyButton).not.toHaveAttribute('disabled');
+
+      // Uncheck the collection checkbox
+      await collectionCheckbox.click();
+      await page.waitForTimeout(300);
+
+      // All pdf-item checkboxes should be unchecked
+      for (let i = 0; i < pdfCheckboxCount; i++) {
+        await expect(pdfCheckboxesInCollection.nth(i)).toHaveJSProperty('checked', false);
+      }
+
+      // moveCopyButton should be disabled
+      await expect(moveCopyButton).toHaveAttribute('disabled', '');
+
+      // Close drawer
+      const closeButton = page.locator('sl-button[name="closeDrawer"]');
+      await closeButton.click();
+      await page.waitForTimeout(300);
+
+      await performLogout(page);
+    } finally {
+      stopErrorMonitoring();
+    }
+  });
+
+  test('batch dialog opens and Move button is disabled with 0 collections selected', async ({ page }) => {
+    const consoleLogs = setupTestConsoleCapture(page);
+    const stopErrorMonitoring = setupErrorFailure(consoleLogs, ALLOWED_ERROR_PATTERNS);
+
+    try {
+      await navigateAndLogin(page, TEST_REVIEWER.username, TEST_REVIEWER.password);
+      await page.waitForTimeout(1000);
+
+      // Open file drawer
+      const drawerTrigger = page.locator('sl-button[name="fileDrawerTrigger"]');
+      await drawerTrigger.click();
+      await page.waitForTimeout(500);
+
+      const pdfItems = page.locator('.pdf-item');
+      const pdfCount = await pdfItems.count();
+      if (pdfCount === 0) {
+        const closeButton = page.locator('sl-button[name="closeDrawer"]');
+        await closeButton.click();
+        await page.waitForTimeout(300);
+        await performLogout(page);
+        return;
+      }
+
+      // Expand collections so pdf-item checkboxes become visible
+      await expandAllCollections(page);
+
+      // Check first pdf-item checkbox
+      const firstPdfCheckbox = pdfItems.first().locator('sl-checkbox');
+      await firstPdfCheckbox.click();
+      await page.waitForTimeout(300);
+
+      // Click moveCopyButton to open the dialog
+      const moveCopyButton = page.locator('sl-button[name="moveCopyButton"]');
+      await moveCopyButton.click();
+      await page.waitForTimeout(500);
+
+      // Dialog should be open
+      const dialog = page.locator('sl-dialog[name="moveFilesDialog"]');
+      await expect(dialog).toHaveAttribute('open', '');
+
+      // moveBtn and copyBtn should both be disabled (no collections selected yet)
+      const moveBtn = dialog.locator('sl-button[name="moveBtn"]');
+      const copyBtn = dialog.locator('sl-button[name="copyBtn"]');
+      await expect(moveBtn).toHaveAttribute('disabled', '');
+      await expect(copyBtn).toHaveAttribute('disabled', '');
+
+      // If there are collection checkboxes in the dialog, test their interaction
+      const collectionCheckboxes = dialog.locator('[name="collectionsList"] sl-checkbox');
+      const dialogCollectionCount = await collectionCheckboxes.count();
+
+      if (dialogCollectionCount > 0) {
+        // Check first collection checkbox
+        await collectionCheckboxes.first().click();
+        await page.waitForTimeout(200);
+
+        // With exactly 1 collection selected: moveBtn enabled, copyBtn enabled
+        await expect(moveBtn).not.toHaveAttribute('disabled');
+        await expect(copyBtn).not.toHaveAttribute('disabled');
+
+        if (dialogCollectionCount > 1) {
+          // Check second collection checkbox
+          await collectionCheckboxes.nth(1).click();
+          await page.waitForTimeout(200);
+
+          // With >1 collections selected: moveBtn disabled (move only works to 1 target), copyBtn enabled
+          await expect(moveBtn).toHaveAttribute('disabled', '');
+          await expect(copyBtn).not.toHaveAttribute('disabled');
+        }
+      }
+
+      // Cancel the dialog
+      const cancelBtn = dialog.locator('sl-button[name="cancel"]');
+      await cancelBtn.click();
+      await page.waitForTimeout(300);
+
+      // Close drawer
+      const closeButton = page.locator('sl-button[name="closeDrawer"]');
+      await closeButton.click();
+      await page.waitForTimeout(300);
+
+      await performLogout(page);
+    } finally {
+      stopErrorMonitoring();
+    }
+  });
+
+  test('dismiss dialog with cancel returns without moving', async ({ page }) => {
+    const consoleLogs = setupTestConsoleCapture(page);
+    const stopErrorMonitoring = setupErrorFailure(consoleLogs, ALLOWED_ERROR_PATTERNS);
+
+    try {
+      await navigateAndLogin(page, TEST_REVIEWER.username, TEST_REVIEWER.password);
+      await page.waitForTimeout(1000);
+
+      // Open file drawer
+      const drawerTrigger = page.locator('sl-button[name="fileDrawerTrigger"]');
+      await drawerTrigger.click();
+      await page.waitForTimeout(500);
+
+      const pdfItems = page.locator('.pdf-item');
+      const pdfCount = await pdfItems.count();
+      if (pdfCount === 0) {
+        const closeButton = page.locator('sl-button[name="closeDrawer"]');
+        await closeButton.click();
+        await page.waitForTimeout(300);
+        await performLogout(page);
+        return;
+      }
+
+      // Expand collections so pdf-item checkboxes become visible
+      await expandAllCollections(page);
+
+      // Check first pdf-item checkbox
+      const firstPdfCheckbox = pdfItems.first().locator('sl-checkbox');
+      await firstPdfCheckbox.click();
+      await page.waitForTimeout(300);
+
+      // Open the dialog
+      const moveCopyButton = page.locator('sl-button[name="moveCopyButton"]');
+      await moveCopyButton.click();
+      await page.waitForTimeout(500);
+
+      const dialog = page.locator('sl-dialog[name="moveFilesDialog"]');
+      await expect(dialog).toHaveAttribute('open', '');
+
+      // Click cancel button
+      const cancelBtn = dialog.locator('sl-button[name="cancel"]');
+      await cancelBtn.click();
+      await page.waitForTimeout(300);
+
+      // Dialog should no longer be open
+      await expect(dialog).not.toHaveAttribute('open', '');
+
+      // moveCopyButton should still be present in the drawer
+      await expect(moveCopyButton).toBeVisible();
+
+      // Close drawer
+      const closeButton = page.locator('sl-button[name="closeDrawer"]');
+      await closeButton.click();
+      await page.waitForTimeout(300);
+
+      await performLogout(page);
+    } finally {
+      stopErrorMonitoring();
+    }
+  });
+
+});


### PR DESCRIPTION
## Summary

- Replaces the single-document Move/Copy toolbar button with a batch operation driven from the Collection & Files Drawer
- Per-document checkboxes on every PDF item in the file tree; collection checkboxes toggle all children and show indeterminate state for partial selections
- New Move/Copy footer button (visible to reviewer/admin roles) opens a dialog with collections grouped by project — Move requires exactly 1 target collection, Copy allows multiple
- `MoveFilesPlugin` refactored as a pure service plugin exposing `showBatchDialog()`; `FileSelectionDrawerPlugin` handles all selection state and batch execution
- `xml_id` removed from move/copy API endpoints — operations always act on PDF and all associated TEI files atomically

## Changes

- `fastapi_app/routers/files_move.py`, `files_copy.py` — remove unused `xml_id` field from request/response
- `app/src/templates/move-files-dialog.html` + types — redesign dialog with collection checkboxes and separate Move/Copy buttons
- `app/src/plugins/move-files.js` — refactor as service plugin with `showBatchDialog()`
- `app/src/templates/file-selection-drawer.html` + types — add `moveCopyButton` to footer
- `app/src/plugins/file-selection-drawer.js` — add `#selectedDocuments`, per-doc checkboxes, selection sync, `#handleMoveCopy()`
- `tests/e2e/tests/file-drawer-batch-move.spec.js` — 5 E2E tests (all passing)

## Test plan

- [ ] Open file drawer as reviewer/admin — verify move/copy button is visible but disabled
- [ ] Check a document checkbox — verify move/copy button enables
- [ ] Check a collection checkbox — verify all child doc checkboxes check and button enables
- [ ] Partially uncheck docs in a collection — verify collection checkbox goes indeterminate
- [ ] Click Move/Copy button — verify dialog opens with collections grouped by project
- [ ] Select 1 collection — verify Move and Copy both enabled; select 2 — verify Move disabled
- [ ] Confirm Move — verify document disappears from source, appears in target after reload
- [ ] Confirm Copy — verify document appears in both collections
- [ ] Click New in dialog — verify new collection is created and appears as checked checkbox
- [ ] Close drawer — verify doc selection is cleared on reopen
- [ ] All 5 E2E tests pass: `node tests/e2e-runner.js tests/e2e/tests/file-drawer-batch-move.spec.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)